### PR TITLE
Add CORS middleware to backend

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -18,3 +18,7 @@ Each entry includes:
 **Context**: The stack previously only had backend and frontend containers. Database used local SQLite and file uploads stored on local disk. We want containerized Postgres and object storage plus shared env configuration.
 **Decision**: Added `db` and `minio` services to `docker-compose.yml` with persistent volumes and exposed ports. Created `.env` file with dev credentials and referenced it from all services. Updated backend code to read `DATABASE_URL` and `SECRET_KEY` from environment variables so Compose configuration applies automatically.
 **Reasoning**: Provides consistent dev environment with stateful services and avoids hardcoding secrets or SQLite path. Environment variables make configuration flexible for production.
+## [2025-07-22 10:04:49 UTC] Decision: Enable CORS middleware
+**Context**: Frontend on a different port needs to call API during development.
+**Decision**: Added `CORSMiddleware` with origins from `ALLOWED_ORIGINS` env variable defaulting to `*`.
+**Reasoning**: Allows local frontend development without errors while remaining configurable for production.

--- a/api/main.py
+++ b/api/main.py
@@ -1,8 +1,26 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+import os
+
 from .routers import api_router
 from .database import Base, engine
 
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="PersonaForge API")
+
+origins_env = os.environ.get("ALLOWED_ORIGINS", "*")
+if origins_env == "*":
+    allow_origins = ["*"]
+else:
+    allow_origins = [o.strip() for o in origins_env.split(",") if o.strip()]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=allow_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.include_router(api_router)


### PR DESCRIPTION
## Summary
- enable CORS using FastAPI `CORSMiddleware`
- origins come from `ALLOWED_ORIGINS` env variable or `*` by default
- log reasoning in `NOTEBOOK.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f61ad9e788322b1338207c0156898