### PR TITLE
Implement persona export endpoint

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -18,3 +18,7 @@ Each entry includes:
 **Context**: The stack previously only had backend and frontend containers. Database used local SQLite and file uploads stored on local disk. We want containerized Postgres and object storage plus shared env configuration.
 **Decision**: Added `db` and `minio` services to `docker-compose.yml` with persistent volumes and exposed ports. Created `.env` file with dev credentials and referenced it from all services. Updated backend code to read `DATABASE_URL` and `SECRET_KEY` from environment variables so Compose configuration applies automatically.
 **Reasoning**: Provides consistent dev environment with stateful services and avoids hardcoding secrets or SQLite path. Environment variables make configuration flexible for production.
+## [2025-07-22 10:06:00 UTC] Decision: Add export endpoint
+**Context**: API_SPEC defined a route to export personas but it was missing from the code.
+**Decision**: Implemented `POST /export/{persona_id}` router using Jinja2 to render persona data to Markdown, then optionally convert to PDF with `fpdf2`. Results are saved under `uploads/` and returned as a URL. Added `ExportRequest` and `ExportResponse` schemas and included the router in the main API. Dependencies `jinja2`, `markdown`, and `fpdf2` were added.
+**Reasoning**: Enables basic persona export functionality matching the spec while keeping implementation lightweight and extensible for future template customization.

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from . import auth, users, cv, personas, gap_analysis
+from . import auth, users, cv, personas, gap_analysis, export
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -8,3 +8,4 @@ api_router.include_router(users.router)
 api_router.include_router(cv.router)
 api_router.include_router(personas.router)
 api_router.include_router(gap_analysis.router)
+api_router.include_router(export.router)

--- a/api/routers/export.py
+++ b/api/routers/export.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from jinja2 import Template
+from fpdf import FPDF
+import markdown
+
+from .. import schemas, models
+from ..deps import get_db, get_current_user
+
+UPLOAD_DIR = Path("uploads")
+UPLOAD_DIR.mkdir(exist_ok=True)
+
+DEFAULT_TEMPLATE = Template(
+    """# {{ persona.title }}\n\n{{ persona.summary or '' }}\n\n"""
+    "{% if persona.tags %}**Tags:** {{ persona.tags|join(', ') }}{% endif %}\n"
+)
+
+router = APIRouter(prefix="/export", tags=["export"])
+
+
+@router.post("/{persona_id}", response_model=schemas.ExportResponse)
+def export_persona(
+    persona_id: str,
+    request: schemas.ExportRequest,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    persona = (
+        db.query(models.Persona)
+        .filter(models.Persona.id == persona_id, models.Persona.user_id == current_user.id)
+        .first()
+    )
+    if not persona:
+        raise HTTPException(status_code=404, detail="Persona not found")
+
+    template = DEFAULT_TEMPLATE
+    if request.template_id:
+        tmpl = db.query(models.Template).filter(models.Template.id == request.template_id).first()
+        if not tmpl:
+            raise HTTPException(status_code=404, detail="Template not found")
+        if tmpl.engine == models.TemplateEngine.jinja:
+            template = Template(tmpl.config.get("template", DEFAULT_TEMPLATE.source))
+        else:  # markdown engine
+            template = Template(tmpl.config.get("template", DEFAULT_TEMPLATE.source))
+
+    markdown_text = template.render(persona=persona)
+
+    filename = f"{uuid4()}"
+    if request.format == schemas.ExportFormat.md:
+        path = UPLOAD_DIR / f"{filename}.md"
+        path.write_text(markdown_text)
+    else:
+        html = markdown.markdown(markdown_text)
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_auto_page_break(auto=True, margin=15)
+        pdf.set_font("Arial", size=12)
+        for line in html.splitlines():
+            pdf.multi_cell(0, 10, line)
+        path = UPLOAD_DIR / f"{filename}.pdf"
+        pdf.output(str(path))
+
+    return schemas.ExportResponse(file_url=f"/uploads/{path.name}")

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -3,6 +3,7 @@ from .user import UserOut, UserUpdate
 from .cv import CVPreview, CVDetail
 from .persona import PersonaCreate, PersonaOut
 from .gap import GapIssue, GapReportOut
+from .export import ExportRequest, ExportResponse, ExportFormat
 
 __all__ = [
     "SignupRequest",
@@ -16,4 +17,7 @@ __all__ = [
     "PersonaOut",
     "GapIssue",
     "GapReportOut",
+    "ExportRequest",
+    "ExportResponse",
+    "ExportFormat",
 ]

--- a/api/schemas/export.py
+++ b/api/schemas/export.py
@@ -1,0 +1,17 @@
+from enum import Enum
+from typing import Optional
+from pydantic import BaseModel
+
+
+class ExportFormat(str, Enum):
+    pdf = "pdf"
+    md = "md"
+
+
+class ExportRequest(BaseModel):
+    format: ExportFormat
+    template_id: Optional[str] = None
+
+
+class ExportResponse(BaseModel):
+    file_url: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ sqlalchemy
 python-multipart
 passlib[bcrypt]
 python-jose[cryptography]
+jinja2
+markdown
+fpdf2


### PR DESCRIPTION
## Summary
- add schemas for export request/response
- implement `/export/{persona_id}` router with Jinja2 markdown rendering and optional PDF output
- include router in API router registration
- extend requirements with PDF/templating libs
- document export decision in NOTEBOOK

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687f61aac9b08322bd1596038dac268a