### PR TITLE
Add knowledgebase router and schemas

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -18,3 +18,7 @@ Each entry includes:
 **Context**: The stack previously only had backend and frontend containers. Database used local SQLite and file uploads stored on local disk. We want containerized Postgres and object storage plus shared env configuration.
 **Decision**: Added `db` and `minio` services to `docker-compose.yml` with persistent volumes and exposed ports. Created `.env` file with dev credentials and referenced it from all services. Updated backend code to read `DATABASE_URL` and `SECRET_KEY` from environment variables so Compose configuration applies automatically.
 **Reasoning**: Provides consistent dev environment with stateful services and avoids hardcoding secrets or SQLite path. Environment variables make configuration flexible for production.
+## [2025-07-22 10:05:26 UTC] Decision: Store KB clarifications as entries
+**Context**: Implemented `/knowledgebase` endpoints. Needed to decide how to persist clarification answers.**
+**Decision**: Represent clarifications as `KnowledgeBaseEntry` records with `type` `preference` and `source` `user_answer`. This reuses the existing table without introducing a new model.
+**Reasoning**: Using the same schema keeps the knowledge base unified and avoids managing a separate answers table. Each answer simply contributes a new entry, making retrieval via `GET /knowledgebase` straightforward.

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from . import auth, users, cv, personas, gap_analysis
+from . import auth, users, cv, personas, gap_analysis, knowledgebase
 
 api_router = APIRouter()
 api_router.include_router(auth.router)
@@ -8,3 +8,4 @@ api_router.include_router(users.router)
 api_router.include_router(cv.router)
 api_router.include_router(personas.router)
 api_router.include_router(gap_analysis.router)
+api_router.include_router(knowledgebase.router)

--- a/api/routers/knowledgebase.py
+++ b/api/routers/knowledgebase.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..deps import get_db, get_current_user
+
+router = APIRouter(prefix="/knowledgebase", tags=["knowledgebase"])
+
+
+@router.get("", response_model=list[schemas.KBEntryOut])
+def list_entries(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    entries = (
+        db.query(models.KnowledgeBaseEntry)
+        .filter(models.KnowledgeBaseEntry.user_id == current_user.id)
+        .all()
+    )
+    return entries
+
+
+@router.post("/clarify", response_model=list[schemas.KBEntryOut])
+def clarify_answers(
+    data: schemas.ClarifyRequest,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    if not data.answers:
+        raise HTTPException(status_code=400, detail="answers required")
+    new_entries = []
+    for _qid, answer in data.answers.items():
+        entry = models.KnowledgeBaseEntry(
+            user_id=current_user.id,
+            type=models.KBType.preference,
+            value=answer,
+            source=models.KBSource.user_answer,
+        )
+        db.add(entry)
+        new_entries.append(entry)
+    db.commit()
+    for entry in new_entries:
+        db.refresh(entry)
+    return new_entries

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -3,6 +3,7 @@ from .user import UserOut, UserUpdate
 from .cv import CVPreview, CVDetail
 from .persona import PersonaCreate, PersonaOut
 from .gap import GapIssue, GapReportOut
+from .knowledgebase import KBEntryOut, ClarifyRequest
 
 __all__ = [
     "SignupRequest",
@@ -16,4 +17,6 @@ __all__ = [
     "PersonaOut",
     "GapIssue",
     "GapReportOut",
+    "KBEntryOut",
+    "ClarifyRequest",
 ]

--- a/api/schemas/knowledgebase.py
+++ b/api/schemas/knowledgebase.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from typing import Dict
+
+
+class KBEntryOut(BaseModel):
+    id: str
+    type: str
+    value: str
+    source: str
+
+    class Config:
+        orm_mode = True
+
+
+class ClarifyRequest(BaseModel):
+    answers: Dict[str, str]


### PR DESCRIPTION
## Summary
- implement `GET /knowledgebase` and `POST /knowledgebase/clarify`
- expose new router in API router registry
- add pydantic models for knowledgebase entries
- log schema decision in NOTEBOOK

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f61abd92c832294119ab06ca8bcd9