### PR TITLE
Add psycopg2 driver and note Docker rebuild

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -18,3 +18,7 @@ Each entry includes:
 **Context**: The stack previously only had backend and frontend containers. Database used local SQLite and file uploads stored on local disk. We want containerized Postgres and object storage plus shared env configuration.
 **Decision**: Added `db` and `minio` services to `docker-compose.yml` with persistent volumes and exposed ports. Created `.env` file with dev credentials and referenced it from all services. Updated backend code to read `DATABASE_URL` and `SECRET_KEY` from environment variables so Compose configuration applies automatically.
 **Reasoning**: Provides consistent dev environment with stateful services and avoids hardcoding secrets or SQLite path. Environment variables make configuration flexible for production.
+## [2025-07-22 10:04:44 UTC] Decision: Add Postgres driver dependency
+**Context**: Postgres is used via SQLAlchemy but the driver was missing from `requirements.txt` and thus from the backend container.
+**Decision**: Appended `psycopg2-binary` to `requirements.txt` and documented rebuilding the backend Docker image in `README.md`.
+**Reasoning**: `psycopg2-binary` ensures database connectivity when running in Docker or locally. Documentation reminds developers to rebuild so the dependency is installed.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,12 @@ Users upload CVs (PDF, DOCX), from which our system extracts structured data, pe
 ├── AGENT.md
 ├── NOTEBOOK.md        # Codex logs its thoughts & decisions here
 ```
+
+## 🐳 Docker Setup
+
+The backend Docker image installs packages from `requirements.txt`. After adding `psycopg2-binary` to enable PostgreSQL connections, rebuild the container so the new dependency is included:
+
+```bash
+docker compose build backend
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy
 python-multipart
 passlib[bcrypt]
 python-jose[cryptography]
+psycopg2-binary


### PR DESCRIPTION
## Summary
- add psycopg2-binary to backend requirements
- document that rebuilding the backend container installs the driver
- log reasoning in NOTEBOOK

## Testing
- `python3 -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687f61acaa5c832284accbf01236fd28