### PR TITLE
feat(frontend): add auth form components

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -42,3 +42,7 @@ Each entry includes:
 **Context**: Frontend on a different port needs to call API during development.
 **Decision**: Added `CORSMiddleware` with origins from `ALLOWED_ORIGINS` env variable defaulting to `*`.
 **Reasoning**: Allows local frontend development without errors while remaining configurable for production.
+## [2025-08-03 04:41:47 UTC] Decision: Add auth form components
+**Context**: Frontend lacked reusable components and theming for authentication screens.
+**Decision**: Introduced Button and Input primitives, LoginForm and SignupForm components, centralized API helper, and Tailwind theme tokens with next-themes provider.
+**Reasoning**: Establishes consistent, accessible building blocks and prepares the app for dark mode across login and signup pages.

--- a/web/components/LoginForm.tsx
+++ b/web/components/LoginForm.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Input } from './ui/Input';
+import { Button } from './ui/Button';
+import { login } from '../utils/api';
+
+export function LoginForm() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const data = await login(email, password);
+      localStorage.setItem('token', data.token);
+      router.push('/dashboard');
+    } catch (err) {
+      setError('Invalid credentials');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 rounded-2xl bg-surface p-6 shadow-md dark:bg-surface-dark">
+      {error && (
+        <p className="text-error dark:text-error-dark" role="alert">
+          {error}
+        </p>
+      )}
+      <Input label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
+      <Input label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+      <Button type="submit" disabled={loading} aria-busy={loading}>
+        {loading ? 'Loading…' : 'Login'}
+      </Button>
+    </form>
+  );
+}

--- a/web/components/SignupForm.tsx
+++ b/web/components/SignupForm.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Input } from './ui/Input';
+import { Button } from './ui/Button';
+import { signup } from '../utils/api';
+
+export function SignupForm() {
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const data = await signup(name, email, password);
+      localStorage.setItem('token', data.token);
+      router.push('/dashboard');
+    } catch (err) {
+      setError('Signup failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 rounded-2xl bg-surface p-6 shadow-md dark:bg-surface-dark">
+      {error && (
+        <p className="text-error dark:text-error-dark" role="alert">
+          {error}
+        </p>
+      )}
+      <Input label="Name" type="text" value={name} onChange={e => setName(e.target.value)} required />
+      <Input label="Email" type="email" value={email} onChange={e => setEmail(e.target.value)} required />
+      <Input label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+      <Button type="submit" disabled={loading} aria-busy={loading}>
+        {loading ? 'Creating…' : 'Create Account'}
+      </Button>
+    </form>
+  );
+}

--- a/web/components/ui/Button.tsx
+++ b/web/components/ui/Button.tsx
@@ -1,0 +1,12 @@
+import { ButtonHTMLAttributes } from 'react';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export function Button({ className = '', ...props }: ButtonProps) {
+  return (
+    <button
+      className={`rounded-md bg-primary px-4 py-2 text-white hover:bg-primary-dark disabled:opacity-50 dark:bg-primary-dark focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-dark ${className}`}
+      {...props}
+    />
+  );
+}

--- a/web/components/ui/Input.tsx
+++ b/web/components/ui/Input.tsx
@@ -1,0 +1,22 @@
+import { InputHTMLAttributes, useId } from 'react';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+}
+
+export function Input({ label, id, className = '', ...props }: InputProps) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  return (
+    <div>
+      <label htmlFor={inputId} className="block text-sm font-medium text-onSurface dark:text-onSurface-dark">
+        {label}
+      </label>
+      <input
+        id={inputId}
+        className={`mt-1 block w-full rounded-md border border-gray-300 bg-surface p-2 text-onSurface dark:border-gray-600 dark:bg-surface-dark dark:text-onSurface-dark ${className}`}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,10 +10,16 @@
       "dependencies": {
         "autoprefixer": "10.4.16",
         "next": "14.2.3",
+        "next-themes": "^0.2.1",
         "postcss": "8.4.33",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "tailwindcss": "3.4.4"
+      },
+      "devDependencies": {
+        "@types/node": "24.1.0",
+        "@types/react": "19.1.9",
+        "typescript": "5.9.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -289,6 +295,26 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
+      "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/ansi-regex": {
@@ -582,6 +608,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -1031,6 +1064,17 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -1743,6 +1787,27 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/web/package.json
+++ b/web/package.json
@@ -8,11 +8,17 @@
     "start": "next start"
   },
   "dependencies": {
+    "autoprefixer": "10.4.16",
     "next": "14.2.3",
+    "next-themes": "^0.2.1",
+    "postcss": "8.4.33",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "tailwindcss": "3.4.4",
-    "autoprefixer": "10.4.16",
-    "postcss": "8.4.33"
+    "tailwindcss": "3.4.4"
+  },
+  "devDependencies": {
+    "@types/node": "24.1.0",
+    "@types/react": "19.1.9",
+    "typescript": "5.9.2"
   }
 }

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,6 +1,11 @@
-import '../styles/globals.css'
-import type { AppProps } from 'next/app'
+import '../styles/globals.css';
+import type { AppProps } from 'next/app';
+import { ThemeProvider } from 'next-themes';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
 }

--- a/web/pages/login.tsx
+++ b/web/pages/login.tsx
@@ -1,40 +1,9 @@
-import { useState } from 'react'
-import { useRouter } from 'next/router'
+import { LoginForm } from '../components/LoginForm';
 
 export default function Login() {
-  const router = useRouter()
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    const res = await fetch('http://backend:8000/auth/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password })
-    })
-    if (res.ok) {
-      router.push('/dashboard')
-    }
-  }
-
   return (
-    <form onSubmit={handleSubmit} className="p-8 space-y-4">
-      <input
-        type="email"
-        placeholder="Email"
-        value={email}
-        onChange={e => setEmail(e.target.value)}
-        className="border p-2"
-      />
-      <input
-        type="password"
-        placeholder="Password"
-        value={password}
-        onChange={e => setPassword(e.target.value)}
-        className="border p-2"
-      />
-      <button type="submit" className="bg-blue-500 text-white p-2">Login</button>
-    </form>
-  )
+    <main className="flex min-h-screen items-center justify-center bg-surface dark:bg-surface-dark">
+      <LoginForm />
+    </main>
+  );
 }

--- a/web/pages/signup.tsx
+++ b/web/pages/signup.tsx
@@ -1,48 +1,9 @@
-import { useState } from 'react'
-import { useRouter } from 'next/router'
+import { SignupForm } from '../components/SignupForm';
 
 export default function Signup() {
-  const router = useRouter()
-  const [name, setName] = useState('')
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    const res = await fetch('http://backend:8000/auth/signup', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password, name })
-    })
-    if (res.ok) {
-      router.push('/dashboard')
-    }
-  }
-
   return (
-    <form onSubmit={handleSubmit} className="p-8 space-y-4">
-      <input
-        type="text"
-        placeholder="Name"
-        value={name}
-        onChange={e => setName(e.target.value)}
-        className="border p-2"
-      />
-      <input
-        type="email"
-        placeholder="Email"
-        value={email}
-        onChange={e => setEmail(e.target.value)}
-        className="border p-2"
-      />
-      <input
-        type="password"
-        placeholder="Password"
-        value={password}
-        onChange={e => setPassword(e.target.value)}
-        className="border p-2"
-      />
-      <button type="submit" className="bg-blue-500 text-white p-2">Sign Up</button>
-    </form>
-  )
+    <main className="flex min-h-screen items-center justify-center bg-surface dark:bg-surface-dark">
+      <SignupForm />
+    </main>
+  );
 }

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply text-base text-onSurface bg-surface dark:bg-surface-dark dark:text-onSurface-dark;
+  }
+}

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,11 +1,19 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}'
   ],
   theme: {
-    extend: {}
+    extend: {
+      colors: {
+        primary: { DEFAULT: '#3B82F6', dark: '#60A5FA' },
+        surface: { DEFAULT: '#ffffff', dark: '#1f2937' },
+        onSurface: { DEFAULT: '#111827', dark: '#e5e7eb' },
+        error: { DEFAULT: '#EF4444', dark: '#F87171' }
+      }
+    }
   },
   plugins: []
 }

--- a/web/utils/api.ts
+++ b/web/utils/api.ts
@@ -1,0 +1,29 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://backend:8000';
+
+export interface TokenResponse {
+  token: string;
+}
+
+export async function login(email: string, password: string): Promise<TokenResponse> {
+  const res = await fetch(`${API_BASE_URL}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) {
+    throw new Error('Login failed');
+  }
+  return res.json();
+}
+
+export async function signup(name: string, email: string, password: string): Promise<TokenResponse> {
+  const res = await fetch(`${API_BASE_URL}/auth/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, email, password }),
+  });
+  if (!res.ok) {
+    throw new Error('Signup failed');
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- introduce theme provider and semantic tailwind tokens
- add reusable UI primitives and auth form components
- wire login and signup pages to new API helper

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ee79f37248322af538675d98e19c0