### PR TITLE
feat(frontend): add core screens and components

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -46,3 +46,7 @@ Each entry includes:
 **Context**: Frontend lacked reusable components and theming for authentication screens.
 **Decision**: Introduced Button and Input primitives, LoginForm and SignupForm components, centralized API helper, and Tailwind theme tokens with next-themes provider.
 **Reasoning**: Establishes consistent, accessible building blocks and prepares the app for dark mode across login and signup pages.
+## [2025-08-03 04:55:04 UTC] Decision: Build core application screens
+**Context**: Only authentication pages existed on the frontend and the dashboard/other screens from FRONTEND_OUTLINE were missing.
+**Decision**: Added API utilities and implemented Dashboard, Upload, Apply, and Persona detail pages with reusable components (UploadButton, PersonaCard, KnowledgeBaseSummary, CVParsePreview, job tailoring tools, and export controls).
+**Reasoning**: Aligns UI with project outline, enabling CV uploads, persona management, gap analysis and role-specific tailoring directly from the frontend.

--- a/web/components/CVParsePreview.tsx
+++ b/web/components/CVParsePreview.tsx
@@ -1,0 +1,17 @@
+import { CVData } from '../utils/api';
+
+interface Props {
+  cv: CVData | null;
+}
+
+export function CVParsePreview({ cv }: Props) {
+  if (!cv) return null;
+  return (
+    <div className="mt-4 rounded-xl border border-gray-300 p-4 dark:border-gray-700">
+      <h3 className="mb-2 text-lg font-semibold text-onSurface dark:text-onSurface-dark">Parsed CV</h3>
+      <pre className="whitespace-pre-wrap text-sm text-onSurface dark:text-onSurface-dark">
+        {JSON.stringify(cv.data, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/web/components/EditorPanel.tsx
+++ b/web/components/EditorPanel.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { Persona, updatePersona } from '../utils/api';
+import { Input } from './ui/Input';
+import { Textarea } from './ui/Textarea';
+import { Button } from './ui/Button';
+
+interface Props {
+  persona: Persona;
+  onUpdated: (p: Persona) => void;
+}
+
+export function EditorPanel({ persona, onUpdated }: Props) {
+  const [name, setName] = useState(persona.name);
+  const [summary, setSummary] = useState(persona.summary || '');
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      const updated = await updatePersona(persona.id, { name, summary });
+      onUpdated(updated);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSave} className="space-y-4 rounded-xl border border-gray-300 p-4 dark:border-gray-700">
+      <h3 className="text-lg font-semibold text-onSurface dark:text-onSurface-dark">Edit Persona</h3>
+      <Input label="Name" value={name} onChange={e => setName(e.target.value)} required />
+      <Textarea label="Summary" value={summary} onChange={e => setSummary(e.target.value)} rows={4} />
+      <Button type="submit" disabled={saving}>
+        {saving ? 'Saving…' : 'Save'}
+      </Button>
+    </form>
+  );
+}

--- a/web/components/ExportButton.tsx
+++ b/web/components/ExportButton.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { exportPersona } from '../utils/api';
+import { Button } from './ui/Button';
+
+interface Props {
+  personaId: string;
+  template: string;
+}
+
+export function ExportButton({ personaId, template }: Props) {
+  const [loading, setLoading] = useState(false);
+
+  async function handleClick() {
+    setLoading(true);
+    try {
+      const res = await exportPersona(personaId, template);
+      window.open(res.url, '_blank');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Button type="button" onClick={handleClick} disabled={loading}>
+      {loading ? 'Exporting…' : 'Export'}
+    </Button>
+  );
+}

--- a/web/components/GapAnalysisPanel.tsx
+++ b/web/components/GapAnalysisPanel.tsx
@@ -1,0 +1,21 @@
+import { GapIssue } from '../utils/api';
+
+interface Props {
+  issues: GapIssue[];
+}
+
+export function GapAnalysisPanel({ issues }: Props) {
+  if (!issues.length) return null;
+  return (
+    <div className="rounded-xl border border-gray-300 p-4 dark:border-gray-700">
+      <h3 className="mb-2 text-lg font-semibold text-onSurface dark:text-onSurface-dark">Gap Analysis</h3>
+      <ul className="space-y-1">
+        {issues.map(issue => (
+          <li key={issue.id} className="text-sm text-onSurface dark:text-onSurface-dark">
+            <span className="font-medium">{issue.field}:</span> {issue.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/components/JobDescriptionInput.tsx
+++ b/web/components/JobDescriptionInput.tsx
@@ -1,0 +1,18 @@
+import { Textarea } from './ui/Textarea';
+
+interface Props {
+  value: string;
+  onChange: (val: string) => void;
+}
+
+export function JobDescriptionInput({ value, onChange }: Props) {
+  return (
+    <Textarea
+      label="Job Description"
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      rows={8}
+      required
+    />
+  );
+}

--- a/web/components/KnowledgeBaseSummary.tsx
+++ b/web/components/KnowledgeBaseSummary.tsx
@@ -1,0 +1,20 @@
+import { KnowledgeBaseEntry } from '../utils/api';
+
+interface Props {
+  entries: KnowledgeBaseEntry[];
+}
+
+export function KnowledgeBaseSummary({ entries }: Props) {
+  return (
+    <div className="rounded-xl border border-gray-300 p-4 dark:border-gray-700">
+      <h3 className="mb-2 text-lg font-semibold text-onSurface dark:text-onSurface-dark">Knowledge Base</h3>
+      <ul className="list-disc space-y-1 pl-5">
+        {entries.map(e => (
+          <li key={e.id} className="text-sm text-onSurface dark:text-onSurface-dark">
+            {e.content}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/components/PersonaCard.tsx
+++ b/web/components/PersonaCard.tsx
@@ -1,0 +1,29 @@
+import { Persona } from '../utils/api';
+
+interface PersonaCardProps {
+  persona: Persona;
+  onClick?: () => void;
+}
+
+export function PersonaCard({ persona, onClick }: PersonaCardProps) {
+  return (
+    <div
+      onClick={onClick}
+      className="cursor-pointer rounded-xl border border-gray-300 p-4 shadow-sm hover:bg-surface-hover dark:border-gray-700 dark:hover:bg-surface-hover-dark"
+    >
+      <h3 className="text-lg font-semibold text-onSurface dark:text-onSurface-dark">{persona.name}</h3>
+      {persona.summary && (
+        <p className="text-sm text-onSurface-variant dark:text-onSurface-variant-dark">{persona.summary}</p>
+      )}
+      {persona.tags && (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {persona.tags.map(tag => (
+            <span key={tag} className="rounded bg-primary px-2 py-1 text-xs text-white dark:bg-primary-dark">
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/PersonaSelector.tsx
+++ b/web/components/PersonaSelector.tsx
@@ -1,0 +1,23 @@
+import { Persona } from '../utils/api';
+import { Select } from './ui/Select';
+
+interface Props {
+  personas: Persona[];
+  value: string;
+  onChange: (id: string) => void;
+}
+
+export function PersonaSelector({ personas, value, onChange }: Props) {
+  return (
+    <Select label="Persona" value={value} onChange={e => onChange(e.target.value)} required>
+      <option value="" disabled>
+        Select persona
+      </option>
+      {personas.map(p => (
+        <option key={p.id} value={p.id}>
+          {p.name}
+        </option>
+      ))}
+    </Select>
+  );
+}

--- a/web/components/TailoringSuggestions.tsx
+++ b/web/components/TailoringSuggestions.tsx
@@ -1,0 +1,19 @@
+interface Props {
+  suggestions: string[];
+}
+
+export function TailoringSuggestions({ suggestions }: Props) {
+  if (!suggestions.length) return null;
+  return (
+    <div className="rounded-xl border border-gray-300 p-4 dark:border-gray-700">
+      <h3 className="mb-2 text-lg font-semibold text-onSurface dark:text-onSurface-dark">Tailoring Suggestions</h3>
+      <ul className="list-disc space-y-1 pl-5">
+        {suggestions.map((s, i) => (
+          <li key={i} className="text-sm text-onSurface dark:text-onSurface-dark">
+            {s}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/components/TemplateSelector.tsx
+++ b/web/components/TemplateSelector.tsx
@@ -1,0 +1,15 @@
+import { Select } from './ui/Select';
+
+interface Props {
+  value: string;
+  onChange: (val: string) => void;
+}
+
+export function TemplateSelector({ value, onChange }: Props) {
+  return (
+    <Select label="Template" value={value} onChange={e => onChange(e.target.value)} required>
+      <option value="markdown">Markdown</option>
+      <option value="pdf">PDF</option>
+    </Select>
+  );
+}

--- a/web/components/UploadButton.tsx
+++ b/web/components/UploadButton.tsx
@@ -1,0 +1,40 @@
+import { useRef, useState } from 'react';
+import { uploadCV } from '../utils/api';
+import { Button } from './ui/Button';
+
+interface UploadButtonProps {
+  onUploaded: (id: string) => void;
+}
+
+export function UploadButton({ onUploaded }: UploadButtonProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setLoading(true);
+    try {
+      const res = await uploadCV(file);
+      onUploaded(res.id);
+    } finally {
+      setLoading(false);
+      if (inputRef.current) inputRef.current.value = '';
+    }
+  }
+
+  return (
+    <div>
+      <input
+        type="file"
+        ref={inputRef}
+        onChange={handleFileChange}
+        className="hidden"
+        aria-hidden="true"
+      />
+      <Button type="button" disabled={loading} onClick={() => inputRef.current?.click()}>
+        {loading ? 'Uploading…' : 'Upload CV'}
+      </Button>
+    </div>
+  );
+}

--- a/web/components/ui/Select.tsx
+++ b/web/components/ui/Select.tsx
@@ -1,0 +1,24 @@
+import { SelectHTMLAttributes, useId } from 'react';
+
+interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  label: string;
+}
+
+export function Select({ label, id, className = '', children, ...props }: SelectProps) {
+  const generatedId = useId();
+  const selectId = id ?? generatedId;
+  return (
+    <div>
+      <label htmlFor={selectId} className="block text-sm font-medium text-onSurface dark:text-onSurface-dark">
+        {label}
+      </label>
+      <select
+        id={selectId}
+        className={`mt-1 block w-full rounded-md border border-gray-300 bg-surface p-2 text-onSurface dark:border-gray-600 dark:bg-surface-dark dark:text-onSurface-dark ${className}`}
+        {...props}
+      >
+        {children}
+      </select>
+    </div>
+  );
+}

--- a/web/components/ui/Textarea.tsx
+++ b/web/components/ui/Textarea.tsx
@@ -1,0 +1,22 @@
+import { TextareaHTMLAttributes, useId } from 'react';
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label: string;
+}
+
+export function Textarea({ label, id, className = '', ...props }: TextareaProps) {
+  const generatedId = useId();
+  const textId = id ?? generatedId;
+  return (
+    <div>
+      <label htmlFor={textId} className="block text-sm font-medium text-onSurface dark:text-onSurface-dark">
+        {label}
+      </label>
+      <textarea
+        id={textId}
+        className={`mt-1 block w-full rounded-md border border-gray-300 bg-surface p-2 text-onSurface dark:border-gray-600 dark:bg-surface-dark dark:text-onSurface-dark ${className}`}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/web/pages/apply.tsx
+++ b/web/pages/apply.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { JobDescriptionInput } from '../components/JobDescriptionInput';
+import { PersonaSelector } from '../components/PersonaSelector';
+import { TailoringSuggestions } from '../components/TailoringSuggestions';
+import { getPersonas, roleMatch, Persona } from '../utils/api';
+import { Button } from '../components/ui/Button';
+
+export default function ApplyPage() {
+  const [personas, setPersonas] = useState<Persona[]>([]);
+  const [selected, setSelected] = useState('');
+  const [job, setJob] = useState('');
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    getPersonas().then(setPersonas).catch(() => setPersonas([]));
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await roleMatch({ persona_id: selected, job_description: job });
+      setSuggestions(res.suggestions);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="p-8">
+      <h1 className="mb-4 text-2xl font-bold">Tailor Application</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <JobDescriptionInput value={job} onChange={setJob} />
+        <PersonaSelector personas={personas} value={selected} onChange={setSelected} />
+        <Button type="submit" disabled={loading || !selected || !job}>
+          {loading ? 'Analyzing…' : 'Analyze'}
+        </Button>
+      </form>
+      <div className="mt-6">
+        <TailoringSuggestions suggestions={suggestions} />
+      </div>
+    </main>
+  );
+}

--- a/web/pages/dashboard.tsx
+++ b/web/pages/dashboard.tsx
@@ -1,8 +1,50 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import {
+  getMe,
+  getPersonas,
+  getKnowledgeBase,
+  Persona,
+  KnowledgeBaseEntry,
+} from '../utils/api';
+import { UploadButton } from '../components/UploadButton';
+import { PersonaCard } from '../components/PersonaCard';
+import { KnowledgeBaseSummary } from '../components/KnowledgeBaseSummary';
+
 export default function Dashboard() {
+  const router = useRouter();
+  const [user, setUser] = useState<string>('');
+  const [personas, setPersonas] = useState<Persona[]>([]);
+  const [kb, setKb] = useState<KnowledgeBaseEntry[]>([]);
+
+  useEffect(() => {
+    getMe().then(u => setUser(u.name));
+    getPersonas().then(setPersonas);
+    getKnowledgeBase().then(setKb).catch(() => setKb([]));
+  }, []);
+
+  function handleUploaded(id: string) {
+    router.push({ pathname: '/upload', query: { id } });
+  }
+
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold">Dashboard</h1>
-      <p>Welcome to PersonaForge!</p>
-    </div>
-  )
+    <main className="space-y-6 p-8">
+      <h1 className="text-2xl font-bold">Welcome, {user}</h1>
+      <div>
+        <UploadButton onUploaded={handleUploaded} />
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <KnowledgeBaseSummary entries={kb} />
+        <div className="grid gap-4">
+          {personas.map(p => (
+            <PersonaCard
+              key={p.id}
+              persona={p}
+              onClick={() => router.push(`/persona/${p.id}`)}
+            />
+          ))}
+        </div>
+      </div>
+    </main>
+  );
 }

--- a/web/pages/persona/[id].tsx
+++ b/web/pages/persona/[id].tsx
@@ -1,0 +1,38 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { EditorPanel } from '../../components/EditorPanel';
+import { GapAnalysisPanel } from '../../components/GapAnalysisPanel';
+import { TemplateSelector } from '../../components/TemplateSelector';
+import { ExportButton } from '../../components/ExportButton';
+import { getPersona, getGapAnalysis, Persona, GapIssue } from '../../utils/api';
+
+export default function PersonaDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [persona, setPersona] = useState<Persona | null>(null);
+  const [issues, setIssues] = useState<GapIssue[]>([]);
+  const [template, setTemplate] = useState('markdown');
+
+  useEffect(() => {
+    if (typeof id === 'string') {
+      getPersona(id).then(setPersona);
+      getGapAnalysis(id).then(setIssues).catch(() => setIssues([]));
+    }
+  }, [id]);
+
+  if (!persona) return <main className="p-8">Loading…</main>;
+
+  return (
+    <main className="space-y-6 p-8">
+      <h1 className="text-2xl font-bold">{persona.name}</h1>
+      <EditorPanel persona={persona} onUpdated={setPersona} />
+      <GapAnalysisPanel issues={issues} />
+      <div className="flex items-end gap-4">
+        <div className="w-48">
+          <TemplateSelector value={template} onChange={setTemplate} />
+        </div>
+        <ExportButton personaId={persona.id} template={template} />
+      </div>
+    </main>
+  );
+}

--- a/web/pages/upload.tsx
+++ b/web/pages/upload.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { UploadButton } from '../components/UploadButton';
+import { CVParsePreview } from '../components/CVParsePreview';
+import { getCV, CVData } from '../utils/api';
+
+export default function UploadPage() {
+  const router = useRouter();
+  const [cv, setCv] = useState<CVData | null>(null);
+
+  useEffect(() => {
+    const { id } = router.query;
+    if (typeof id === 'string') {
+      getCV(id).then(setCv);
+    }
+  }, [router.query]);
+
+  async function handleUploaded(id: string) {
+    const data = await getCV(id);
+    setCv(data);
+    router.replace({ pathname: '/upload', query: { id } }, undefined, { shallow: true });
+  }
+
+  return (
+    <main className="p-8">
+      <h1 className="mb-4 text-2xl font-bold">Upload CV</h1>
+      <UploadButton onUploaded={handleUploaded} />
+      <CVParsePreview cv={cv} />
+    </main>
+  );
+}

--- a/web/utils/api.ts
+++ b/web/utils/api.ts
@@ -27,3 +27,167 @@ export async function signup(name: string, email: string, password: string): Pro
   }
   return res.json();
 }
+
+function authHeader(): Record<string, string> {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export async function getMe(): Promise<User> {
+  const res = await fetch(`${API_BASE_URL}/users/me`, {
+    headers: { ...authHeader() },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to load user');
+  }
+  return res.json();
+}
+
+export interface Persona {
+  id: string;
+  name: string;
+  summary?: string;
+  tags?: string[];
+}
+
+export async function getPersonas(): Promise<Persona[]> {
+  const res = await fetch(`${API_BASE_URL}/personas`, {
+    headers: { ...authHeader() },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to load personas');
+  }
+  return res.json();
+}
+
+export interface KnowledgeBaseEntry {
+  id: number;
+  type: string;
+  content: string;
+}
+
+export async function getKnowledgeBase(): Promise<KnowledgeBaseEntry[]> {
+  const res = await fetch(`${API_BASE_URL}/knowledgebase`, {
+    headers: { ...authHeader() },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to load knowledge base');
+  }
+  return res.json();
+}
+
+export interface CVUploadResponse {
+  id: string;
+}
+
+export async function uploadCV(file: File): Promise<CVUploadResponse> {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch(`${API_BASE_URL}/cv/upload`, {
+    method: 'POST',
+    headers: { ...authHeader() },
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error('Upload failed');
+  }
+  return res.json();
+}
+
+export interface CVData {
+  id: string;
+  name: string;
+  data: any;
+}
+
+export async function getCV(id: string): Promise<CVData> {
+  const res = await fetch(`${API_BASE_URL}/cv/${id}`, {
+    headers: { ...authHeader() },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to load CV');
+  }
+  return res.json();
+}
+
+export async function getPersona(id: string): Promise<Persona> {
+  const res = await fetch(`${API_BASE_URL}/personas/${id}`, {
+    headers: { ...authHeader() },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to load persona');
+  }
+  return res.json();
+}
+
+export async function updatePersona(id: string, data: Partial<Persona>): Promise<Persona> {
+  const res = await fetch(`${API_BASE_URL}/personas/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to update persona');
+  }
+  return res.json();
+}
+
+export interface GapIssue {
+  id: string;
+  field: string;
+  message: string;
+}
+
+export async function getGapAnalysis(id: string): Promise<GapIssue[]> {
+  const res = await fetch(`${API_BASE_URL}/gap_analysis/${id}`, {
+    headers: { ...authHeader() },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to load gap analysis');
+  }
+  const data = await res.json();
+  return data.issues ?? [];
+}
+
+export interface RoleMatchRequest {
+  persona_id: string;
+  job_description: string;
+}
+
+export interface RoleMatchResponse {
+  suggestions: string[];
+}
+
+export async function roleMatch(req: RoleMatchRequest): Promise<RoleMatchResponse> {
+  const res = await fetch(`${API_BASE_URL}/gap_analysis/role_match`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
+    body: JSON.stringify(req),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to analyze role');
+  }
+  return res.json();
+}
+
+export interface ExportResponse {
+  url: string;
+}
+
+export async function exportPersona(id: string, template: string): Promise<ExportResponse> {
+  const res = await fetch(`${API_BASE_URL}/export/${id}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
+    body: JSON.stringify({ template }),
+  });
+  if (!res.ok) {
+    throw new Error('Export failed');
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- Implement dashboard with persona management and knowledge base summary
- Add CV upload, application tailoring, and persona detail pages
- Expand API utilities and reusable UI components for editing, exporting, and gap analysis

## Testing
- `npm --prefix web run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eeae878188322877fd91e00ad64b8