### PR TITLE
Implement structured knowledge base retrieval

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -69,3 +69,8 @@ Each entry includes:
 **Context**: Required extracting structured CV data (experience, education, skills) from uploaded files.
 **Decision**: Created `CVParser` using OpenAI with a dedicated prompt, added PDF/DOCX text extraction and a `/cv/{id}/parse` endpoint storing raw text and structured JSON.
 **Reasoning**: Converts unstructured CV content into database-ready JSON, enabling downstream persona and analysis features.
+
+## [2025-08-03 08:08:01 UTC] Decision: Grouped knowledge base retrieval
+**Context**: `/knowledgebase` endpoint returned a flat list and frontend expected `content` fields, diverging from API_SPEC's structured groups.
+**Decision**: Returned grouped categories (skills, tools, domains, soft skills, preferences) via `KnowledgeBaseOut`, updated TypeScript utilities and UI to render sections, and added tests verifying clarification answers populate the profile.
+**Reasoning**: Structured response aligns API with specification and enables iterative Q&A to build a comprehensive user knowledge base.

--- a/api/routers/knowledgebase.py
+++ b/api/routers/knowledgebase.py
@@ -7,7 +7,7 @@ from ..deps import get_db, get_current_user
 router = APIRouter(prefix="/knowledgebase", tags=["knowledgebase"])
 
 
-@router.get("", response_model=list[schemas.KBEntryOut])
+@router.get("", response_model=schemas.KnowledgeBaseOut)
 def list_entries(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
@@ -17,7 +17,25 @@ def list_entries(
         .filter(models.KnowledgeBaseEntry.user_id == current_user.id)
         .all()
     )
-    return entries
+    grouped = {
+        "skills": [],
+        "tools": [],
+        "domains": [],
+        "soft_skills": [],
+        "preferences": [],
+    }
+    for e in entries:
+        if e.type == models.KBType.skill:
+            grouped["skills"].append(e.value)
+        elif e.type == models.KBType.tool:
+            grouped["tools"].append(e.value)
+        elif e.type == models.KBType.domain:
+            grouped["domains"].append(e.value)
+        elif e.type == models.KBType.soft_skill:
+            grouped["soft_skills"].append(e.value)
+        elif e.type == models.KBType.preference:
+            grouped["preferences"].append(e.value)
+    return grouped
 
 
 @router.post("/clarify", response_model=list[schemas.KBEntryOut])

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -3,7 +3,7 @@ from .user import UserOut, UserUpdate
 from .cv import CVPreview, CVDetail
 from .persona import PersonaCreate, PersonaOut
 from .gap import GapIssue, GapReportOut, TeamGapRequest
-from .knowledgebase import KBEntryOut, ClarifyRequest
+from .knowledgebase import KBEntryOut, ClarifyRequest, KnowledgeBaseOut
 from .export import ExportRequest, ExportResponse, ExportFormat
 
 __all__ = [
@@ -21,6 +21,7 @@ __all__ = [
     "TeamGapRequest",
     "KBEntryOut",
     "ClarifyRequest",
+    "KnowledgeBaseOut",
     "ExportRequest",
     "ExportResponse",
     "ExportFormat",

--- a/api/schemas/knowledgebase.py
+++ b/api/schemas/knowledgebase.py
@@ -1,15 +1,23 @@
-from pydantic import BaseModel
-from typing import Dict
+from pydantic import BaseModel, ConfigDict
+from typing import Dict, List
+from uuid import UUID
+
+
+class KnowledgeBaseOut(BaseModel):
+    skills: List[str] = []
+    tools: List[str] = []
+    domains: List[str] = []
+    soft_skills: List[str] = []
+    preferences: List[str] = []
 
 
 class KBEntryOut(BaseModel):
-    id: str
+    id: UUID
     type: str
     value: str
     source: str
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ClarifyRequest(BaseModel):

--- a/tests/test_knowledgebase.py
+++ b/tests/test_knowledgebase.py
@@ -1,0 +1,65 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.database import Base
+from api.deps import get_db
+
+
+@pytest.fixture()
+def client(tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    engine = create_engine(db_url, connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def signup_get_token(client: TestClient) -> str:
+    resp = client.post(
+        "/auth/signup",
+        json={"email": "user@example.com", "password": "secret", "name": "User"},
+    )
+    return resp.json()["token"]
+
+
+def test_clarify_and_list_knowledgebase(client):
+    token = signup_get_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Initial KB should be empty groups
+    resp = client.get("/knowledgebase", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "skills": [],
+        "tools": [],
+        "domains": [],
+        "soft_skills": [],
+        "preferences": [],
+    }
+
+    # Clarify with a preference answer
+    clarify_resp = client.post(
+        "/knowledgebase/clarify",
+        json={"answers": {"q1": "Remote work"}},
+        headers=headers,
+    )
+    assert clarify_resp.status_code == 200
+
+    # KB should now include the preference
+    resp2 = client.get("/knowledgebase", headers=headers)
+    assert resp2.status_code == 200
+    assert resp2.json()["preferences"] == ["Remote work"]

--- a/web/components/KnowledgeBaseSummary.tsx
+++ b/web/components/KnowledgeBaseSummary.tsx
@@ -1,20 +1,36 @@
-import { KnowledgeBaseEntry } from '../utils/api';
+import { KnowledgeBase } from '../utils/api';
 
 interface Props {
-  entries: KnowledgeBaseEntry[];
+  kb: KnowledgeBase;
 }
 
-export function KnowledgeBaseSummary({ entries }: Props) {
+export function KnowledgeBaseSummary({ kb }: Props) {
+  const sections = [
+    { title: 'Skills', items: kb.skills },
+    { title: 'Tools', items: kb.tools },
+    { title: 'Domains', items: kb.domains },
+    { title: 'Soft Skills', items: kb.soft_skills },
+    { title: 'Preferences', items: kb.preferences },
+  ];
   return (
     <div className="rounded-xl border border-gray-300 p-4 dark:border-gray-700">
       <h3 className="mb-2 text-lg font-semibold text-onSurface dark:text-onSurface-dark">Knowledge Base</h3>
-      <ul className="list-disc space-y-1 pl-5">
-        {entries.map(e => (
-          <li key={e.id} className="text-sm text-onSurface dark:text-onSurface-dark">
-            {e.content}
-          </li>
-        ))}
-      </ul>
+      {sections.map(section => (
+        <div key={section.title} className="mb-4 last:mb-0">
+          <h4 className="text-md font-medium text-onSurface dark:text-onSurface-dark">{section.title}</h4>
+          <ul className="list-disc space-y-1 pl-5">
+            {section.items.length > 0 ? (
+              section.items.map((item, idx) => (
+                <li key={idx} className="text-sm text-onSurface dark:text-onSurface-dark">
+                  {item}
+                </li>
+              ))
+            ) : (
+              <li className="text-sm text-onSurface dark:text-onSurface-dark opacity-50">None</li>
+            )}
+          </ul>
+        </div>
+      ))}
     </div>
   );
 }

--- a/web/pages/dashboard.tsx
+++ b/web/pages/dashboard.tsx
@@ -5,7 +5,7 @@ import {
   getPersonas,
   getKnowledgeBase,
   Persona,
-  KnowledgeBaseEntry,
+  KnowledgeBase,
 } from '../utils/api';
 import { UploadButton } from '../components/UploadButton';
 import { PersonaCard } from '../components/PersonaCard';
@@ -15,12 +15,28 @@ export default function Dashboard() {
   const router = useRouter();
   const [user, setUser] = useState<string>('');
   const [personas, setPersonas] = useState<Persona[]>([]);
-  const [kb, setKb] = useState<KnowledgeBaseEntry[]>([]);
+  const [kb, setKb] = useState<KnowledgeBase>({
+    skills: [],
+    tools: [],
+    domains: [],
+    soft_skills: [],
+    preferences: [],
+  });
 
   useEffect(() => {
     getMe().then(u => setUser(u.name));
     getPersonas().then(setPersonas);
-    getKnowledgeBase().then(setKb).catch(() => setKb([]));
+    getKnowledgeBase()
+      .then(setKb)
+      .catch(() =>
+        setKb({
+          skills: [],
+          tools: [],
+          domains: [],
+          soft_skills: [],
+          preferences: [],
+        })
+      );
   }, []);
 
   function handleUploaded(id: string) {
@@ -34,7 +50,7 @@ export default function Dashboard() {
         <UploadButton onUploaded={handleUploaded} />
       </div>
       <div className="grid gap-4 md:grid-cols-2">
-        <KnowledgeBaseSummary entries={kb} />
+        <KnowledgeBaseSummary kb={kb} />
         <div className="grid gap-4">
           {personas.map(p => (
             <PersonaCard

--- a/web/utils/api.ts
+++ b/web/utils/api.ts
@@ -66,13 +66,15 @@ export async function getPersonas(): Promise<Persona[]> {
   return res.json();
 }
 
-export interface KnowledgeBaseEntry {
-  id: number;
-  type: string;
-  content: string;
+export interface KnowledgeBase {
+  skills: string[];
+  tools: string[];
+  domains: string[];
+  soft_skills: string[];
+  preferences: string[];
 }
 
-export async function getKnowledgeBase(): Promise<KnowledgeBaseEntry[]> {
+export async function getKnowledgeBase(): Promise<KnowledgeBase> {
   const res = await fetch(`${API_BASE_URL}/knowledgebase`, {
     headers: { ...authHeader() },
   });


### PR DESCRIPTION
## Summary
- return grouped skills, tools, domains, soft skills, and preferences from `GET /knowledgebase`
- update frontend utilities and dashboard to display new knowledge base sections
- add API test covering knowledge base clarification flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f17f2931083228fc4f216e2cfe0ab