### PR TITLE
Enhance gap analysis with knowledge base and inline tailoring actions

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -108,3 +108,8 @@ Each entry includes:
 **Context**: The taxonomy approach requires further design and isn't ready for production.
 **Decision**: Removed service usage and replaced its implementation with a `NotImplementedError` stub.
 **Reasoning**: Pausing the feature avoids premature complexity while signaling unfinished functionality if imported.
+
+## [2025-08-03 10:49:57 UTC] Decision: Expand role gap analysis with knowledge base and inline fixes
+**Context**: Role-specific gap analysis ignored stored skills and the UI lacked a way to apply AI suggestions.
+**Decision**: Included user knowledge base entries in the job match prompt and added an "Apply" button to gap suggestions that patches persona fields.
+**Reasoning**: Leveraging the full knowledge base yields richer gap detection while inline actions enable one-click tailoring of personas.

--- a/api/services/prompts.py
+++ b/api/services/prompts.py
@@ -15,10 +15,13 @@ Respond in JSON with two keys:
 
 CV_JOB_MATCH_TEMPLATE = Template(
     """
-You are an AI recruiter comparing a candidate's CV against a job posting.
+You are an AI recruiter comparing a candidate's CV and knowledge base against a job posting.
 
 CV:
 ${cv}
+
+Knowledge Base (JSON):
+${kb}
 
 Job Description:
 ${job}

--- a/tests/test_gap_analysis_agent.py
+++ b/tests/test_gap_analysis_agent.py
@@ -44,3 +44,48 @@ def test_gap_analysis_agent_uses_template(monkeypatch):
         "cv_analysis"
     ].substitute(cv="my cv")
     assert result.questions == ["Q1"]
+
+
+def test_role_match_includes_kb(monkeypatch):
+    captured = {}
+
+    class DummyCompletions:
+        def __init__(self, outer):
+            self.outer = outer
+
+        def create(self, model, messages):
+            self.outer["messages"] = messages
+            content = json.dumps({"issues": [], "questions": ["Q1"]})
+            return type(
+                "Resp",
+                (),
+                {
+                    "choices": [
+                        type(
+                            "Choice",
+                            (),
+                            {"message": type("Msg", (), {"content": content})()},
+                        )
+                    ]
+                },
+            )()
+
+    class DummyChat:
+        def __init__(self, outer):
+            self.completions = DummyCompletions(outer)
+
+    class DummyClient:
+        def __init__(self):
+            self.chat = DummyChat(captured)
+
+    monkeypatch.setattr("api.services.gap_analysis.OpenAI", DummyClient)
+
+    agent = GapAnalysisAgent("cv_job_match")
+    kb_json = json.dumps({"skills": ["Python"]})
+    result = agent.start(cv="my cv", job="desc", kb=kb_json)
+
+    expected = prompts.GAP_ANALYSIS_PROMPTS["cv_job_match"].substitute(
+        cv="my cv", job="desc", kb=kb_json
+    )
+    assert captured["messages"][0]["content"] == expected
+    assert result.questions == ["Q1"]

--- a/web/components/GapAnalysisPanel.tsx
+++ b/web/components/GapAnalysisPanel.tsx
@@ -1,20 +1,46 @@
-import { GapReport } from '../utils/api';
+import { useState } from 'react';
+import { GapReport, updatePersona } from '../utils/api';
 
 interface Props {
   report: GapReport;
+  personaId: string;
 }
 
-export function GapAnalysisPanel({ report }: Props) {
-  const { issues, questions } = report;
+export function GapAnalysisPanel({ report, personaId }: Props) {
+  const [issues, setIssues] = useState(report.issues);
+  const { questions } = report;
   if (!issues.length && !questions.length) return null;
+
+  async function apply(idx: number) {
+    const issue = issues[idx];
+    try {
+      await updatePersona(personaId, { [issue.field]: issue.suggestion });
+      setIssues((prev) => prev.filter((_, i) => i !== idx));
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   return (
     <div className="rounded-xl border border-gray-300 p-4 dark:border-gray-700">
       <h3 className="mb-2 text-lg font-semibold text-onSurface dark:text-onSurface-dark">Gap Analysis</h3>
       {issues.length > 0 && (
         <ul className="mb-4 space-y-1">
           {issues.map((issue, idx) => (
-            <li key={idx} className="text-sm text-onSurface dark:text-onSurface-dark">
-              <span className="font-medium">{issue.field}:</span> {issue.suggestion} ({issue.severity})
+            <li
+              key={idx}
+              className="flex items-start justify-between text-sm text-onSurface dark:text-onSurface-dark"
+            >
+              <span>
+                <span className="font-medium">{issue.field}:</span> {issue.suggestion} ({issue.severity})
+              </span>
+              <button
+                type="button"
+                className="ml-2 text-primary dark:text-primary-dark"
+                onClick={() => apply(idx)}
+              >
+                Apply
+              </button>
             </li>
           ))}
         </ul>

--- a/web/pages/apply.tsx
+++ b/web/pages/apply.tsx
@@ -70,7 +70,7 @@ export default function ApplyPage() {
         </div>
       </form>
       <div className="mt-6 space-y-4">
-        {report && <GapAnalysisPanel report={report} />}
+        {report && <GapAnalysisPanel report={report} personaId={selected} />}
         {tailored && <Textarea label="Tailored CV" value={tailored} readOnly rows={10} />}
       </div>
     </main>


### PR DESCRIPTION
## Summary
- include user knowledge base entries in role-specific gap analysis prompts
- enable applying AI gap suggestions directly to persona fields from the UI
- log design decisions in notebook and add coverage for knowledge base context

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3dda7288832286cb452cd70fa4ad