### PR TITLE
Implement missing persona and team gap analysis features

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -113,3 +113,18 @@ Each entry includes:
 **Context**: Role-specific gap analysis ignored stored skills and the UI lacked a way to apply AI suggestions.
 **Decision**: Included user knowledge base entries in the job match prompt and added an "Apply" button to gap suggestions that patches persona fields.
 **Reasoning**: Leveraging the full knowledge base yields richer gap detection while inline actions enable one-click tailoring of personas.
+
+## [2025-08-03 11:27:30 UTC] Decision: Expose persona creation and deletion in dashboard
+**Context**: Users could edit personas but had no UI to create new ones or remove existing entries. API payloads also used `title` while the frontend expected `name`.
+**Decision**: Added `createPersona` and `deletePersona` helpers that map between `title` and `name`, a `CreatePersonaForm` component, and delete controls on persona cards with dashboard wiring.
+**Reasoning**: Restores full persona lifecycle management from the UI and reconciles backend naming differences for consistent edits.
+
+## [2025-08-03 11:27:30 UTC] Decision: Support knowledge base clarifications in gap analysis panel
+**Context**: Gap analysis returned clarifying questions but the frontend only displayed them without collecting answers.
+**Decision**: Extended `GapAnalysisPanel` with input fields for each question, submission to `/knowledgebase/clarify`, and optional callbacks to refresh data.
+**Reasoning**: Enables iterative Q&A to enrich the knowledge base directly from analysis results.
+
+## [2025-08-03 11:27:30 UTC] Decision: Implement team gap analysis UI
+**Context**: Backend exposed a team gap analysis endpoint, yet the team page lacked any interface to invoke it.
+**Decision**: Added form on `/team` to enter a team description, select multiple personas, and render results via `GapAnalysisPanel` using the `teamGapAnalysis` API.
+**Reasoning**: Completes team-level evaluation workflows and allows collaborative assessment of multiple personas against a shared goal.

--- a/web/components/CreatePersonaForm.tsx
+++ b/web/components/CreatePersonaForm.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { createPersona, Persona } from '../utils/api';
+import { Input } from './ui/Input';
+import { Textarea } from './ui/Textarea';
+import { Button } from './ui/Button';
+
+interface Props {
+  onCreated: (p: Persona) => void;
+}
+
+export function CreatePersonaForm({ onCreated }: Props) {
+  const [name, setName] = useState('');
+  const [summary, setSummary] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const persona = await createPersona({ name, summary });
+      onCreated(persona);
+      setName('');
+      setSummary('');
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <Input label="Name" value={name} onChange={e => setName(e.target.value)} required />
+      <Textarea label="Summary" value={summary} onChange={e => setSummary(e.target.value)} rows={3} />
+      <Button type="submit" disabled={loading}>{loading ? 'Creating…' : 'Create Persona'}</Button>
+    </form>
+  );
+}

--- a/web/components/PersonaCard.tsx
+++ b/web/components/PersonaCard.tsx
@@ -3,14 +3,27 @@ import { Persona } from '../utils/api';
 interface PersonaCardProps {
   persona: Persona;
   onClick?: () => void;
+  onDelete?: () => void;
 }
 
-export function PersonaCard({ persona, onClick }: PersonaCardProps) {
+export function PersonaCard({ persona, onClick, onDelete }: PersonaCardProps) {
   return (
     <div
       onClick={onClick}
-      className="cursor-pointer rounded-xl border border-gray-300 p-4 shadow-sm hover:bg-surface-hover dark:border-gray-700 dark:hover:bg-surface-hover-dark"
+      className="relative cursor-pointer rounded-xl border border-gray-300 p-4 shadow-sm hover:bg-surface-hover dark:border-gray-700 dark:hover:bg-surface-hover-dark"
     >
+      {onDelete && (
+        <button
+          type="button"
+          className="absolute right-2 top-2 text-sm text-red-600"
+          onClick={e => {
+            e.stopPropagation();
+            onDelete();
+          }}
+        >
+          Delete
+        </button>
+      )}
       <h3 className="text-lg font-semibold text-onSurface dark:text-onSurface-dark">{persona.name}</h3>
       {persona.summary && (
         <p className="text-sm text-onSurface-variant dark:text-onSurface-variant-dark">{persona.summary}</p>

--- a/web/pages/dashboard.tsx
+++ b/web/pages/dashboard.tsx
@@ -6,11 +6,13 @@ import {
   getKnowledgeBase,
   Persona,
   KnowledgeBase,
+  deletePersona,
 } from '../utils/api';
 import Link from 'next/link';
 import { UploadButton } from '../components/UploadButton';
 import { PersonaCard } from '../components/PersonaCard';
 import { KnowledgeBaseSummary } from '../components/KnowledgeBaseSummary';
+import { CreatePersonaForm } from '../components/CreatePersonaForm';
 
 export default function Dashboard() {
   const router = useRouter();
@@ -44,6 +46,15 @@ export default function Dashboard() {
     router.push({ pathname: '/upload', query: { id } });
   }
 
+  async function handleDelete(id: string) {
+    try {
+      await deletePersona(id);
+      setPersonas(prev => prev.filter(p => p.id !== id));
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   return (
     <main className="space-y-6 p-8">
       <h1 className="text-2xl font-bold">Welcome, {user}</h1>
@@ -56,11 +67,13 @@ export default function Dashboard() {
       <div className="grid gap-4 md:grid-cols-2">
         <KnowledgeBaseSummary kb={kb} />
         <div className="grid gap-4">
+          <CreatePersonaForm onCreated={p => setPersonas(prev => [...prev, p])} />
           {personas.map(p => (
             <PersonaCard
               key={p.id}
               persona={p}
               onClick={() => router.push(`/persona/${p.id}`)}
+              onDelete={() => handleDelete(p.id)}
             />
           ))}
         </div>

--- a/web/pages/persona/[id].tsx
+++ b/web/pages/persona/[id].tsx
@@ -30,7 +30,7 @@ export default function PersonaDetail() {
     <main className="space-y-6 p-8">
       <h1 className="text-2xl font-bold">{persona.name}</h1>
       <EditorPanel persona={persona} onUpdated={setPersona} />
-      <GapAnalysisPanel report={report} />
+      <GapAnalysisPanel report={report} personaId={persona.id} />
       <div className="flex items-end gap-4">
         <div className="w-48">
           <TemplateSelector value={template} onChange={setTemplate} />

--- a/web/pages/team.tsx
+++ b/web/pages/team.tsx
@@ -2,11 +2,25 @@ import { useEffect, useState } from 'react';
 import { InviteUserForm } from '../components/InviteUserForm';
 import { TeamMemberList } from '../components/TeamMemberList';
 import { TeamPersonaTable } from '../components/TeamPersonaTable';
-import { getTeamMembers, getTeamPersonas, User, Persona } from '../utils/api';
+import {
+  getTeamMembers,
+  getTeamPersonas,
+  teamGapAnalysis,
+  User,
+  Persona,
+  GapReport,
+} from '../utils/api';
+import { Textarea } from '../components/ui/Textarea';
+import { Button } from '../components/ui/Button';
+import { GapAnalysisPanel } from '../components/GapAnalysisPanel';
 
 export default function TeamPage() {
   const [members, setMembers] = useState<User[]>([]);
   const [personas, setPersonas] = useState<Persona[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [description, setDescription] = useState('');
+  const [report, setReport] = useState<GapReport | null>(null);
+  const [analyzing, setAnalyzing] = useState(false);
 
   async function load() {
     try {
@@ -22,6 +36,28 @@ export default function TeamPage() {
     load();
   }, []);
 
+  function toggle(id: string) {
+    setSelected(prev =>
+      prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id],
+    );
+  }
+
+  async function handleAnalyze(e: React.FormEvent) {
+    e.preventDefault();
+    setAnalyzing(true);
+    try {
+      const res = await teamGapAnalysis({
+        persona_ids: selected,
+        team_description: description,
+      });
+      setReport(res);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setAnalyzing(false);
+    }
+  }
+
   return (
     <div className="space-y-8">
       <h1 className="text-2xl font-semibold">Team</h1>
@@ -33,6 +69,33 @@ export default function TeamPage() {
       <section>
         <h2 className="mb-2 text-lg font-medium">Personas</h2>
         <TeamPersonaTable personas={personas} />
+      </section>
+      <section>
+        <h2 className="mb-2 text-lg font-medium">Team Gap Analysis</h2>
+        <form onSubmit={handleAnalyze} className="space-y-4">
+          <Textarea
+            label="Team Description"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            rows={4}
+          />
+          <div className="space-y-1">
+            {personas.map(p => (
+              <label key={p.id} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={selected.includes(p.id)}
+                  onChange={() => toggle(p.id)}
+                />
+                <span>{p.name}</span>
+              </label>
+            ))}
+          </div>
+          <Button type="submit" disabled={analyzing || selected.length === 0 || !description}>
+            {analyzing ? 'Analyzing…' : 'Analyze Team'}
+          </Button>
+        </form>
+        {report && <GapAnalysisPanel report={report} />}
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- add persona creation and deletion UI with API helpers
- enable clarifying answers in gap analysis panel
- build team gap analysis form and fix persona gap analysis id bug

## Testing
- `pytest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f3fd439c08322a835634d35cb9cec