### PR TITLE
Add auth error and user endpoint tests

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -128,3 +128,7 @@ Each entry includes:
 **Context**: Backend exposed a team gap analysis endpoint, yet the team page lacked any interface to invoke it.
 **Decision**: Added form on `/team` to enter a team description, select multiple personas, and render results via `GapAnalysisPanel` using the `teamGapAnalysis` API.
 **Reasoning**: Completes team-level evaluation workflows and allows collaborative assessment of multiple personas against a shared goal.
+## [2025-08-03 12:35:18 UTC] Decision: Enforce UUID usage in routers
+**Context**: Added extensive endpoint tests which surfaced issues where string IDs failed against UUID columns and the `/cv/list` route was shadowed by the dynamic `{cv_id}` path.
+**Decision**: Updated CV, export, gap analysis, and templates routers to use `UUID` parameters and convert request fields accordingly. Reordered CV routes so `/cv/list` resolves correctly.
+**Reasoning**: Aligns request handling with database types, preventing runtime errors and ensuring all endpoints are reachable for testing.

--- a/api/routers/cv.py
+++ b/api/routers/cv.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter, Depends, File, UploadFile, HTTPException
 from sqlalchemy.orm import Session
+from uuid import UUID
 
 from .. import schemas, models
 from ..deps import get_db, get_current_user
@@ -35,9 +36,17 @@ def upload_cv(
     return cv
 
 
+@router.get("/list", response_model=list[schemas.CVPreview])
+def list_cvs(
+    db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)
+):
+    cvs = db.query(models.CV).filter(models.CV.user_id == current_user.id).all()
+    return cvs
+
+
 @router.get("/{cv_id}", response_model=schemas.CVDetail)
 def get_cv(
-    cv_id: str,
+    cv_id: UUID,
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ):
@@ -51,17 +60,9 @@ def get_cv(
     return cv
 
 
-@router.get("/list", response_model=list[schemas.CVPreview])
-def list_cvs(
-    db: Session = Depends(get_db), current_user: models.User = Depends(get_current_user)
-):
-    cvs = db.query(models.CV).filter(models.CV.user_id == current_user.id).all()
-    return cvs
-
-
 @router.post("/{cv_id}/parse", response_model=schemas.CVDetail)
 def parse_cv(
-    cv_id: str,
+    cv_id: UUID,
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ):

--- a/api/routers/gap_analysis.py
+++ b/api/routers/gap_analysis.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 import json
+from uuid import UUID
 
 from .. import schemas, models
 from ..deps import get_db, get_current_user
@@ -11,7 +12,7 @@ router = APIRouter(prefix="/gap_analysis", tags=["gap_analysis"])
 
 @router.get("/{persona_id}", response_model=schemas.GapReportOut)
 def general_gap_analysis(
-    persona_id: str,
+    persona_id: UUID,
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ):
@@ -43,7 +44,8 @@ def role_specific_gap_analysis(
     persona = (
         db.query(models.Persona)
         .filter(
-            models.Persona.id == persona_id, models.Persona.user_id == current_user.id
+            models.Persona.id == UUID(persona_id),
+            models.Persona.user_id == current_user.id,
         )
         .first()
     )
@@ -71,10 +73,11 @@ def team_gap_analysis(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ):
+    persona_ids = [UUID(pid) for pid in data.persona_ids]
     personas = (
         db.query(models.Persona)
         .filter(
-            models.Persona.id.in_(data.persona_ids),
+            models.Persona.id.in_(persona_ids),
             models.Persona.user_id == current_user.id,
         )
         .all()

--- a/api/routers/templates.py
+++ b/api/routers/templates.py
@@ -80,7 +80,10 @@ def tailor_template(
         raise HTTPException(status_code=404, detail="Template not found")
     persona = (
         db.query(models.Persona)
-        .filter(models.Persona.id == request.persona_id, models.Persona.user_id == current_user.id)
+        .filter(
+            models.Persona.id == UUID(request.persona_id),
+            models.Persona.user_id == current_user.id,
+        )
         .first()
     )
     if not persona:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -43,3 +43,25 @@ def test_signup_and_login(client):
     )
     assert login_resp.status_code == 200
     assert login_resp.json()["token"]
+
+
+def test_login_with_wrong_password(client):
+    client.post(
+        "/auth/signup",
+        json={"email": "user@example.com", "password": "correct", "name": "User"},
+    )
+
+    resp = client.post(
+        "/auth/login",
+        json={"email": "user@example.com", "password": "wrong"},
+    )
+    assert resp.status_code == 401
+
+
+def test_signup_duplicate_email(client):
+    data = {"email": "dup@example.com", "password": "secret", "name": "Dup"}
+    first = client.post("/auth/signup", json=data)
+    assert first.status_code == 200
+
+    second = client.post("/auth/signup", json=data)
+    assert second.status_code == 400

--- a/tests/test_cv_endpoints.py
+++ b/tests/test_cv_endpoints.py
@@ -1,0 +1,86 @@
+import io
+from uuid import uuid4
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.main import app
+from api.database import Base
+from api.deps import get_db
+
+
+@pytest.fixture()
+def client(tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    engine = create_engine(db_url, connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def signup_token(client: TestClient) -> str:
+    resp = client.post(
+        "/auth/signup",
+        json={"email": "user@example.com", "password": "secret", "name": "User"},
+    )
+    assert resp.status_code == 200
+    return resp.json()["token"]
+
+
+def test_cv_upload_list_get_parse(client, tmp_path, monkeypatch):
+    from api.routers import cv as cv_router
+
+    cv_router.UPLOAD_DIR = tmp_path / "uploads"
+    cv_router.UPLOAD_DIR.mkdir()
+
+    # patch parser to avoid external calls
+    monkeypatch.setattr("api.routers.cv.CVParser.__init__", lambda self: None)
+    def fake_extract_text(self, path):
+        return "text"
+
+    def fake_parse(self, text):
+        return {"name": "Parsed"}
+
+    monkeypatch.setattr("api.routers.cv.CVParser.extract_text", fake_extract_text)
+    monkeypatch.setattr("api.routers.cv.CVParser.parse", fake_parse)
+
+    token = signup_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    upload_resp = client.post(
+        "/cv/upload",
+        files={"file": ("cv.txt", io.BytesIO(b"content"), "text/plain")},
+        headers=headers,
+    )
+    assert upload_resp.status_code == 200
+    cv_id = upload_resp.json()["id"]
+
+    list_resp = client.get("/cv/list", headers=headers)
+    assert list_resp.status_code == 200
+    assert len(list_resp.json()) == 1
+
+    get_resp = client.get(f"/cv/{cv_id}", headers=headers)
+    assert get_resp.status_code == 200
+
+    parse_resp = client.post(f"/cv/{cv_id}/parse", headers=headers)
+    assert parse_resp.status_code == 200
+    assert parse_resp.json()["parsed_json"] == {"name": "Parsed"}
+
+    missing_id = uuid4()
+    missing_resp = client.get(f"/cv/{missing_id}", headers=headers)
+    assert missing_resp.status_code == 404
+
+    parse_missing = client.post(f"/cv/{missing_id}/parse", headers=headers)
+    assert parse_missing.status_code == 404

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,96 @@
+import pytest
+from pathlib import Path
+from uuid import uuid4
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.main import app
+from api.database import Base
+from api.deps import get_db
+
+
+@pytest.fixture()
+def client(tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    engine = create_engine(db_url, connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def signup_token(client: TestClient) -> str:
+    resp = client.post(
+        "/auth/signup",
+        json={"email": "user@example.com", "password": "secret", "name": "User"},
+    )
+    assert resp.status_code == 200
+    return resp.json()["token"]
+
+
+def create_persona(client: TestClient, headers) -> str:
+    resp = client.post(
+        "/personas",
+        json={"title": "Dev", "summary": "Great", "tags": []},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    return resp.json()["id"]
+
+
+def create_template(client: TestClient, headers) -> str:
+    resp = client.post(
+        "/templates",
+        json={
+            "name": "T",
+            "type": "cv",
+            "engine": "markdown",
+            "config": {"template": "# {{ persona.title }}"},
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    return resp.json()["id"]
+
+
+def test_export_markdown_with_template(client, tmp_path):
+    from api.routers import export as export_router
+
+    export_router.UPLOAD_DIR = tmp_path / "exports"
+    export_router.UPLOAD_DIR.mkdir()
+
+    token = signup_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    persona_id = create_persona(client, headers)
+    template_id = create_template(client, headers)
+
+    resp = client.post(
+        f"/export/{persona_id}",
+        json={"format": "md", "template_id": template_id},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    file_url = resp.json()["file_url"]
+    filename = Path(file_url).name
+    assert (export_router.UPLOAD_DIR / filename).exists()
+    content = (export_router.UPLOAD_DIR / filename).read_text()
+    assert "Dev" in content
+
+    not_found = client.post(
+        f"/export/{uuid4()}",
+        json={"format": "md"},
+        headers=headers,
+    )
+    assert not_found.status_code == 404

--- a/tests/test_gap_analysis_routes.py
+++ b/tests/test_gap_analysis_routes.py
@@ -1,0 +1,96 @@
+import pytest
+from uuid import uuid4
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.main import app
+from api.database import Base
+from api.deps import get_db
+from api.schemas import gap as gap_schemas
+
+
+@pytest.fixture()
+def client(tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    engine = create_engine(db_url, connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def signup_token(client: TestClient) -> str:
+    resp = client.post(
+        "/auth/signup",
+        json={"email": "user@example.com", "password": "secret", "name": "User"},
+    )
+    assert resp.status_code == 200
+    return resp.json()["token"]
+
+
+def create_persona(client: TestClient, headers) -> str:
+    resp = client.post(
+        "/personas",
+        json={"title": "Dev", "summary": "Summary"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    return resp.json()["id"]
+
+
+def test_gap_analysis_endpoints(client, monkeypatch):
+    token = signup_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    persona_id = create_persona(client, headers)
+
+    monkeypatch.setattr(
+        "api.routers.gap_analysis.GapAnalysisAgent.__init__", lambda self, _: None
+    )
+
+    def dummy_start(self, **kwargs):
+        return gap_schemas.GapReportOut(issues=[], questions=["Q"])
+
+    monkeypatch.setattr(
+        "api.routers.gap_analysis.GapAnalysisAgent.start", dummy_start
+    )
+
+    resp = client.get(f"/gap_analysis/{persona_id}", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["questions"] == ["Q"]
+
+    role_resp = client.post(
+        "/gap_analysis/role_match",
+        json={"persona_id": persona_id, "job_description": "JD"},
+        headers=headers,
+    )
+    assert role_resp.status_code == 200
+    assert role_resp.json()["questions"] == ["Q"]
+
+    team_resp = client.post(
+        "/gap_analysis/team",
+        json={"persona_ids": [persona_id], "team_description": "Goal"},
+        headers=headers,
+    )
+    assert team_resp.status_code == 200
+    assert team_resp.json()["questions"] == ["Q"]
+
+    not_found = client.get(f"/gap_analysis/{uuid4()}", headers=headers)
+    assert not_found.status_code == 404
+
+    bad_req = client.post(
+        "/gap_analysis/role_match",
+        json={"persona_id": persona_id},
+        headers=headers,
+    )
+    assert bad_req.status_code == 400

--- a/tests/test_personas.py
+++ b/tests/test_personas.py
@@ -60,3 +60,38 @@ def test_create_and_update_persona(client):
     )
     assert update_resp.status_code == 200
     assert update_resp.json()["summary"] == "Updated"
+
+def test_list_get_delete_persona(client):
+    token = signup_get_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp1 = client.post(
+        "/personas",
+        json={"title": "P1", "summary": ""},
+        headers=headers,
+    )
+    resp2 = client.post(
+        "/personas",
+        json={"title": "P2", "summary": ""},
+        headers=headers,
+    )
+    assert resp1.status_code == 200 and resp2.status_code == 200
+
+    list_resp = client.get("/personas", headers=headers)
+    assert list_resp.status_code == 200
+    personas = list_resp.json()
+    assert len(personas) == 2
+
+    p1_id = personas[0]["id"]
+    get_resp = client.get(f"/personas/{p1_id}", headers=headers)
+    assert get_resp.status_code == 200
+    assert get_resp.json()["id"] == p1_id
+
+    del_resp = client.delete(f"/personas/{p1_id}", headers=headers)
+    assert del_resp.status_code == 200
+
+    list_after = client.get("/personas", headers=headers)
+    assert len(list_after.json()) == 1
+
+    missing = client.get(f"/personas/{p1_id}", headers=headers)
+    assert missing.status_code == 404

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,63 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.main import app
+from api.database import Base
+from api.deps import get_db
+
+
+@pytest.fixture()
+def client(tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    engine = create_engine(db_url, connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def signup_token(client: TestClient) -> str:
+    resp = client.post(
+        "/auth/signup",
+        json={"email": "user@example.com", "password": "secret", "name": "User"},
+    )
+    assert resp.status_code == 200
+    return resp.json()["token"]
+
+
+def test_get_me_returns_current_user(client):
+    token = signup_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.get("/users/me", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["email"] == "user@example.com"
+    assert data["name"] == "User"
+    assert data["plan"] == "free"
+
+
+def test_update_me_changes_fields(client):
+    token = signup_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    update_resp = client.patch(
+        "/users/me", json={"name": "Updated"}, headers=headers
+    )
+    assert update_resp.status_code == 200
+    assert update_resp.json()["name"] == "Updated"
+
+    get_resp = client.get("/users/me", headers=headers)
+    assert get_resp.status_code == 200
+    assert get_resp.json()["name"] == "Updated"
+


### PR DESCRIPTION
## Summary
- expand test suite for CV, export, gap analysis, persona, and template routes
- enforce UUID handling in several routers and expose `/cv/list`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f49554b0c832285edd1b23c533090