### PR TITLE
refactor: migrate to pydantic v2

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -136,3 +136,7 @@ Each entry includes:
 **Context**: The web app had no automated tests covering the login and signup flows.
 **Decision**: Added Jest with React Testing Library, configured Next.js test environment, and wrote tests for `LoginForm` and `SignupForm` to verify API integration, token persistence, and error handling.
 **Reasoning**: Protects critical authentication interactions from regressions and establishes a foundation for broader component testing.
+## [2025-08-03 14:39:13 UTC] Decision: Migrate to Pydantic v2
+**Context**: Deprecation warnings arose from Pydantic v1 patterns (`orm_mode`, `.dict()`) and naive datetime usage in models and token creation.
+**Decision**: Replaced `orm_mode` with `ConfigDict(from_attributes=True)`, switched `.dict()` calls to `model_dump()`, and adopted timezone-aware `datetime.now(timezone.utc)` defaults.
+**Reasoning**: Aligns schemas and routers with Pydantic v2 and Python 3.12, removing warnings and ensuring future compatibility.

--- a/api/models/cv.py
+++ b/api/models/cv.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum as PyEnum
 from sqlalchemy import Column, DateTime, Enum as SQLAlchemyEnum, ForeignKey, String, Text, JSON
 from sqlalchemy.dialects.postgresql import UUID
@@ -23,7 +23,7 @@ class CV(Base):
     raw_text = Column(Text)
     parsed_json = Column(JSON)
     status = Column(SQLAlchemyEnum(CVStatus), default=CVStatus.pending)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     user = relationship("User", back_populates="cvs")
     personas = relationship("Persona", back_populates="base_cv")

--- a/api/models/gap_report.py
+++ b/api/models/gap_report.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum as PyEnum
 from sqlalchemy import Column, DateTime, Enum as SQLAlchemyEnum, ForeignKey, Text, JSON
 from sqlalchemy.dialects.postgresql import UUID
@@ -22,6 +22,6 @@ class GapReport(Base):
     type = Column(SQLAlchemyEnum(GapType), nullable=False)
     input_text = Column(Text)
     issues = Column(JSON)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     persona = relationship("Persona", back_populates="gap_reports")

--- a/api/models/persona.py
+++ b/api/models/persona.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlalchemy import Column, DateTime, ForeignKey, String, Text, JSON
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
@@ -17,8 +17,12 @@ class Persona(Base):
     tags = Column(JSON)
     data = Column(JSON)
     base_cv_id = Column(UUID(as_uuid=True), ForeignKey("cvs.id"))
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
 
     user = relationship("User", back_populates="personas")
     base_cv = relationship("CV", back_populates="personas")

--- a/api/models/team_invite.py
+++ b/api/models/team_invite.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlalchemy import Column, DateTime, Boolean, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
 import uuid
@@ -14,4 +14,4 @@ class TeamInvite(Base):
     email = Column(String, nullable=False)
     token = Column(String, unique=True, nullable=False, default=lambda: uuid.uuid4().hex)
     accepted = Column(Boolean, default=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))

--- a/api/models/user.py
+++ b/api/models/user.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum as PyEnum
 from sqlalchemy import Column, DateTime, Enum as SQLAlchemyEnum, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
@@ -22,7 +22,7 @@ class User(Base):
     password_hash = Column(String, nullable=False)
     name = Column(String, nullable=False)
     plan = Column(SQLAlchemyEnum(PlanEnum), default=PlanEnum.free, nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     team_id = Column(UUID(as_uuid=True), ForeignKey("teams.id"), nullable=True)
 
     team = relationship("Team", back_populates="members", foreign_keys=[team_id])

--- a/api/routers/personas.py
+++ b/api/routers/personas.py
@@ -71,7 +71,7 @@ def update_persona(
     )
     if not persona:
         raise HTTPException(status_code=404, detail="Persona not found")
-    update_data = data.dict(exclude_unset=True)
+    update_data = data.model_dump(exclude_unset=True)
     if "overrides" in update_data:
         persona.data = update_data.pop("overrides")
     for field, value in update_data.items():

--- a/api/routers/templates.py
+++ b/api/routers/templates.py
@@ -22,7 +22,7 @@ def create_template(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ):
-    tmpl = models.Template(**template.dict())
+    tmpl = models.Template(**template.model_dump())
     db.add(tmpl)
     db.commit()
     db.refresh(tmpl)
@@ -47,7 +47,7 @@ def update_template(
     tmpl = db.query(models.Template).filter(models.Template.id == template_id).first()
     if not tmpl:
         raise HTTPException(status_code=404, detail="Template not found")
-    for field, value in template.dict(exclude_unset=True).items():
+    for field, value in template.model_dump(exclude_unset=True).items():
         setattr(tmpl, field, value)
     db.commit()
     db.refresh(tmpl)

--- a/api/routers/users.py
+++ b/api/routers/users.py
@@ -18,7 +18,7 @@ def update_me(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ):
-    for field, value in data.dict(exclude_unset=True).items():
+    for field, value in data.model_dump(exclude_unset=True).items():
         setattr(current_user, field, value)
     db.add(current_user)
     db.commit()

--- a/api/schemas/cv.py
+++ b/api/schemas/cv.py
@@ -1,7 +1,8 @@
 from datetime import datetime
-from typing import List, Optional
-from pydantic import BaseModel
+from typing import Optional
 from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
 
 
 class CVPreview(BaseModel):
@@ -9,8 +10,7 @@ class CVPreview(BaseModel):
     filename: str
     created_at: datetime
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CVDetail(CVPreview):

--- a/api/schemas/persona.py
+++ b/api/schemas/persona.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
-from pydantic import BaseModel
+
+from pydantic import BaseModel, ConfigDict
 
 
 class PersonaBase(BaseModel):
@@ -20,5 +21,4 @@ class PersonaOut(PersonaBase):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/api/schemas/team.py
+++ b/api/schemas/team.py
@@ -1,7 +1,8 @@
 from datetime import datetime
-from uuid import UUID
 from typing import List
-from pydantic import BaseModel, EmailStr
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, EmailStr
 
 from .user import UserOut
 from .persona import PersonaOut
@@ -19,8 +20,7 @@ class TeamInviteOut(BaseModel):
     accepted: bool
     created_at: datetime
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 TeamMembersOut = List[UserOut]

--- a/api/schemas/user.py
+++ b/api/schemas/user.py
@@ -1,6 +1,7 @@
 from typing import Optional
-from pydantic import BaseModel, EmailStr
 from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, EmailStr
 
 
 class UserOut(BaseModel):
@@ -10,8 +11,7 @@ class UserOut(BaseModel):
     plan: str
     team_id: Optional[UUID] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class UserUpdate(BaseModel):

--- a/api/services/auth.py
+++ b/api/services/auth.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import os
@@ -22,7 +22,7 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + (
+    expire = datetime.now(timezone.utc) + (
         expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     )
     to_encode.update({"exp": expire})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
+pydantic>=2
 uvicorn[standard]
 sqlalchemy
 python-multipart


### PR DESCRIPTION
## Summary
- switch schemas to Pydantic v2 using `ConfigDict(from_attributes=True)`
- replace deprecated `.dict()` calls with `model_dump()` in routers
- use timezone-aware `datetime.now(timezone.utc)` for model defaults and JWT expiry

## Testing
- `pip install -r requirements.txt`
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_688f728610d0832291b7e5acb9fbe338