### PR TITLE
Parse CV after upload and show parsed data

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -140,3 +140,8 @@ Each entry includes:
 **Context**: Deprecation warnings arose from Pydantic v1 patterns (`orm_mode`, `.dict()`) and naive datetime usage in models and token creation.
 **Decision**: Replaced `orm_mode` with `ConfigDict(from_attributes=True)`, switched `.dict()` calls to `model_dump()`, and adopted timezone-aware `datetime.now(timezone.utc)` defaults.
 **Reasoning**: Aligns schemas and routers with Pydantic v2 and Python 3.12, removing warnings and ensuring future compatibility.
+
+## [2025-08-04 14:04:09 UTC] Decision: Parse CV immediately on upload
+**Context**: After uploading a CV the frontend fetched its record but never invoked the `/cv/{id}/parse` endpoint. The UI attempted to render `cv.data`, mismatching the backend's `parsed_json` field and leaving the "Parsed CV" section empty.
+**Decision**: Added `parseCV` helper calling the parse endpoint, updated the upload page to invoke parsing and map `parsed_json`, and adjusted the preview component to handle missing data with a progress message.
+**Reasoning**: Automatically parsing newly uploaded CVs and aligning property names ensures users see extracted information instead of an empty placeholder.

--- a/web/components/CVParsePreview.tsx
+++ b/web/components/CVParsePreview.tsx
@@ -6,11 +6,19 @@ interface Props {
 
 export function CVParsePreview({ cv }: Props) {
   if (!cv) return null;
+  if (!cv.parsed_json) {
+    return (
+      <div className="mt-4 rounded-xl border border-gray-300 p-4 dark:border-gray-700">
+        <h3 className="mb-2 text-lg font-semibold text-onSurface dark:text-onSurface-dark">Parsed CV</h3>
+        <p className="text-sm text-onSurface dark:text-onSurface-dark">Parsing in progress…</p>
+      </div>
+    );
+  }
   return (
     <div className="mt-4 rounded-xl border border-gray-300 p-4 dark:border-gray-700">
       <h3 className="mb-2 text-lg font-semibold text-onSurface dark:text-onSurface-dark">Parsed CV</h3>
       <pre className="whitespace-pre-wrap text-sm text-onSurface dark:text-onSurface-dark">
-        {JSON.stringify(cv.data, null, 2)}
+        {JSON.stringify(cv.parsed_json, null, 2)}
       </pre>
     </div>
   );

--- a/web/pages/upload.tsx
+++ b/web/pages/upload.tsx
@@ -2,21 +2,28 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { UploadButton } from '../components/UploadButton';
 import { CVParsePreview } from '../components/CVParsePreview';
-import { getCV, CVData } from '../utils/api';
+import { getCV, parseCV, CVData } from '../utils/api';
 
 export default function UploadPage() {
   const router = useRouter();
   const [cv, setCv] = useState<CVData | null>(null);
 
   useEffect(() => {
+    if (!router.isReady) return;
     const { id } = router.query;
     if (typeof id === 'string') {
-      getCV(id).then(setCv);
+      getCV(id).then((cvData) => {
+        if (!cvData.parsed_json) {
+          parseCV(id).then(setCv);
+        } else {
+          setCv(cvData);
+        }
+      });
     }
-  }, [router.query]);
+  }, [router.isReady, router.query.id]);
 
   async function handleUploaded(id: string) {
-    const data = await getCV(id);
+    const data = await parseCV(id);
     setCv(data);
     router.replace({ pathname: '/upload', query: { id } }, undefined, { shallow: true });
   }

--- a/web/utils/api.ts
+++ b/web/utils/api.ts
@@ -135,8 +135,10 @@ export async function uploadCV(file: File): Promise<CVUploadResponse> {
 
 export interface CVData {
   id: string;
-  name: string;
-  data: any;
+  filename: string;
+  parsed_json?: any;
+  raw_text?: string;
+  created_at?: string;
 }
 
 export async function getCV(id: string): Promise<CVData> {
@@ -145,6 +147,17 @@ export async function getCV(id: string): Promise<CVData> {
   });
   if (!res.ok) {
     throw new Error('Failed to load CV');
+  }
+  return res.json();
+}
+
+export async function parseCV(id: string): Promise<CVData> {
+  const res = await fetch(`${API_BASE_URL}/cv/${id}/parse`, {
+    method: 'POST',
+    headers: { ...authHeader() },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to parse CV');
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary
- Call backend CV parse endpoint after uploading files and expose new `parseCV` utility
- Display parsed CV JSON or parsing progress on upload page
- Log fix in decision notebook

## Testing
- `pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890bcd98e9883229f9b2eb47ce55519