### PR TITLE
Add OAuth2 token endpoint for docs

### DIFF
--- a/API_SPEC.MD
+++ b/API_SPEC.MD
@@ -20,6 +20,13 @@ Authenticate and return JWT.
 * Request: `{ email, password }`
 * Response: `{ token }`
 
+### `POST /auth/token`
+
+OAuth2 password flow endpoint used by interactive docs.
+
+* Request: form fields `username`, `password`
+* Response: `{ token }`
+
 ---
 
 ## 👤 USERS

--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -145,3 +145,7 @@ Each entry includes:
 **Context**: After uploading a CV the frontend fetched its record but never invoked the `/cv/{id}/parse` endpoint. The UI attempted to render `cv.data`, mismatching the backend's `parsed_json` field and leaving the "Parsed CV" section empty.
 **Decision**: Added `parseCV` helper calling the parse endpoint, updated the upload page to invoke parsing and map `parsed_json`, and adjusted the preview component to handle missing data with a progress message.
 **Reasoning**: Automatically parsing newly uploaded CVs and aligning property names ensures users see extracted information instead of an empty placeholder.
+## [2025-08-04 14:15:59 UTC] Decision: Support OAuth2 form login for docs
+**Context**: FastAPI's interactive docs failed to authorize because `/auth/login` expected JSON, while Swagger's OAuth2 flow sends form-encoded credentials.
+**Decision**: Added `/auth/token` endpoint accepting `OAuth2PasswordRequestForm` and updated dependency configuration so Swagger obtains tokens using form fields. Existing `/auth/login` JSON route remains for frontend and tests.
+**Reasoning**: Providing a dedicated form-based token endpoint preserves current API behavior while enabling developers to authenticate through `/docs` without 422 errors.

--- a/api/deps.py
+++ b/api/deps.py
@@ -8,7 +8,7 @@ from .database import SessionLocal
 from .models import User
 from .services.auth import SECRET_KEY, ALGORITHM
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
 
 
 def get_db():


### PR DESCRIPTION
## Summary
- allow FastAPI Swagger to issue tokens via `/auth/token`
- point OAuth2PasswordBearer to the new token endpoint
- document token endpoint in API spec

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890bfca0da883229eddf8f73294f2da