### PR TITLE
Load env vars from .env

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -149,3 +149,7 @@ Each entry includes:
 **Context**: FastAPI's interactive docs failed to authorize because `/auth/login` expected JSON, while Swagger's OAuth2 flow sends form-encoded credentials.
 **Decision**: Added `/auth/token` endpoint accepting `OAuth2PasswordRequestForm` and updated dependency configuration so Swagger obtains tokens using form fields. Existing `/auth/login` JSON route remains for frontend and tests.
 **Reasoning**: Providing a dedicated form-based token endpoint preserves current API behavior while enabling developers to authenticate through `/docs` without 422 errors.
+## [2025-08-04 14:52:40 UTC] Decision: Load `.env` configuration in backend
+**Context**: The FastAPI backend relied on `os.environ` without loading `.env`, so values like `SECRET_KEY` and `DATABASE_URL` were ignored outside Docker.
+**Decision**: Added automatic `.env` loading via `python-dotenv` in `api/__init__.py` and restricted table auto-creation to SQLite to avoid failing when configured for Postgres.
+**Reasoning**: Ensures local development and tests use environment configuration while preventing unintended connections to external databases.

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,8 @@
+"""PersonaForge API package initialization."""
+
+from dotenv import load_dotenv, find_dotenv
+
+# Load environment variables from a `.env` file if present. This allows the
+# backend to pick up configuration such as database URLs and secret keys when
+# running outside of Docker.
+load_dotenv(find_dotenv())

--- a/api/main.py
+++ b/api/main.py
@@ -3,9 +3,13 @@ from fastapi.middleware.cors import CORSMiddleware
 import os
 
 from .routers import api_router
-from .database import Base, engine
+from .database import Base, engine, SQLALCHEMY_DATABASE_URL
 
-Base.metadata.create_all(bind=engine)
+# Only create tables automatically when using the default SQLite database. This
+# avoids attempting to connect to external databases (e.g. Postgres) during
+# application import, which can fail in environments like tests.
+if SQLALCHEMY_DATABASE_URL.startswith("sqlite"):
+    Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="PersonaForge API")
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest
 httpx
 email-validator
+python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ openai
 pypdf
 python-docx
 email-validator
+python-dotenv

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,5 @@
+from api.services import auth
+
+
+def test_env_file_loaded():
+    assert auth.SECRET_KEY == "changeme"


### PR DESCRIPTION
## Summary
- load environment variables from .env during API package initialization
- avoid creating tables when using non-SQLite databases
- add python-dotenv dependency and test ensuring SECRET_KEY from .env is used

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890c82353808322981ff3f514a0d846