### PR TITLE
feat(web): add layout with navigation

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -153,3 +153,7 @@ Each entry includes:
 **Context**: The FastAPI backend relied on `os.environ` without loading `.env`, so values like `SECRET_KEY` and `DATABASE_URL` were ignored outside Docker.
 **Decision**: Added automatic `.env` loading via `python-dotenv` in `api/__init__.py` and restricted table auto-creation to SQLite to avoid failing when configured for Postgres.
 **Reasoning**: Ensures local development and tests use environment configuration while preventing unintended connections to external databases.
+## [2025-08-04 19:27:35 UTC] Decision: Add global layout with navigation
+**Context**: Frontend lacked consistent structure across pages.
+**Decision**: Created `Layout` component with sidebar links, header, footer, and applied it in `_app.tsx` to wrap all pages.
+**Reasoning**: Provides cohesive app-wide design and central navigation elements for future expansion.

--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -1,0 +1,52 @@
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+export function Layout({ children }: LayoutProps) {
+  const year = new Date().getFullYear();
+
+  return (
+    <div className="flex min-h-screen">
+      <aside className="w-64 bg-surface p-4 dark:bg-surface-dark">
+        <nav className="space-y-2">
+          <Link
+            href="/dashboard"
+            className="block rounded px-2 py-1 text-onSurface hover:bg-surface-hover dark:text-onSurface-dark dark:hover:bg-surface-hover-dark"
+          >
+            Dashboard
+          </Link>
+          <Link
+            href="/upload"
+            className="block rounded px-2 py-1 text-onSurface hover:bg-surface-hover dark:text-onSurface-dark dark:hover:bg-surface-hover-dark"
+          >
+            Upload CV
+          </Link>
+          <Link
+            href="/templates"
+            className="block rounded px-2 py-1 text-onSurface hover:bg-surface-hover dark:text-onSurface-dark dark:hover:bg-surface-hover-dark"
+          >
+            Templates
+          </Link>
+          <Link
+            href="/team"
+            className="block rounded px-2 py-1 text-onSurface hover:bg-surface-hover dark:text-onSurface-dark dark:hover:bg-surface-hover-dark"
+          >
+            Team
+          </Link>
+        </nav>
+      </aside>
+      <div className="flex flex-1 flex-col">
+        <header className="bg-surface px-4 py-2 shadow dark:bg-surface-dark">
+          <h1 className="text-xl font-bold text-onSurface dark:text-onSurface-dark">PersonaForge</h1>
+        </header>
+        <main className="flex-1 overflow-y-auto p-4">{children}</main>
+        <footer className="bg-surface px-4 py-2 text-center text-sm text-onSurface-variant shadow-inner dark:bg-surface-dark dark:text-onSurface-variant-dark">
+          &copy; {year} PersonaForge
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,11 +1,14 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
 import { ThemeProvider } from 'next-themes';
+import { Layout } from '../components/Layout';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <Component {...pageProps} />
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add Layout component with sidebar navigation, header, and footer
- wrap all pages in global layout via `_app.tsx`

## Testing
- `cd web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689109227ff083229943538bf836bc0d