### PR TITLE
Enable conversational gap analysis

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -157,3 +157,7 @@ Each entry includes:
 **Context**: Frontend lacked consistent structure across pages.
 **Decision**: Created `Layout` component with sidebar links, header, footer, and applied it in `_app.tsx` to wrap all pages.
 **Reasoning**: Provides cohesive app-wide design and central navigation elements for future expansion.
+## [2025-08-05 06:28:48 UTC] Decision: Enable conversational gap analysis
+**Context**: Gap analysis returned static questions without supporting iterative dialogue.
+**Decision**: Added `GapAskRequest` schema, `/gap_analysis/ask` endpoint, and a chat-style frontend to handle sequential questions using stored messages.
+**Reasoning**: Enables multiple follow-up questions, making the gap analysis process conversational as required.

--- a/api/routers/gap_analysis.py
+++ b/api/routers/gap_analysis.py
@@ -89,3 +89,13 @@ def team_gap_analysis(
     )
     agent = GapAnalysisAgent("team_analysis")
     return agent.start(team=team_text, goal=data.team_description)
+
+
+@router.post("/ask", response_model=schemas.GapReportOut)
+def gap_analysis_followup(
+    data: schemas.GapAskRequest,
+    current_user: models.User = Depends(get_current_user),
+):
+    agent = GapAnalysisAgent(data.analysis_type)
+    agent.messages = [m.model_dump() for m in data.messages]
+    return agent.ask(data.user_input)

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -2,7 +2,7 @@ from .auth import SignupRequest, LoginRequest, TokenResponse
 from .user import UserOut, UserUpdate
 from .cv import CVPreview, CVDetail
 from .persona import PersonaCreate, PersonaOut
-from .gap import GapIssue, GapReportOut, TeamGapRequest
+from .gap import GapIssue, GapReportOut, TeamGapRequest, ChatMessage, GapAskRequest
 from .knowledgebase import KBEntryOut, ClarifyRequest, KnowledgeBaseOut
 from .export import ExportRequest, ExportResponse, ExportFormat
 from .template import (
@@ -27,6 +27,8 @@ __all__ = [
     "GapIssue",
     "GapReportOut",
     "TeamGapRequest",
+    "ChatMessage",
+    "GapAskRequest",
     "TeamInviteCreate",
     "TeamInviteOut",
     "TeamMembersOut",

--- a/api/schemas/gap.py
+++ b/api/schemas/gap.py
@@ -1,6 +1,7 @@
-from typing import List
-from pydantic import BaseModel
 
+
+from typing import List, Literal
+from pydantic import BaseModel
 
 class GapIssue(BaseModel):
     field: str
@@ -8,9 +9,21 @@ class GapIssue(BaseModel):
     severity: str
 
 
+class ChatMessage(BaseModel):
+    role: Literal["system", "user", "assistant"]
+    content: str
+
+
 class GapReportOut(BaseModel):
     issues: List[GapIssue] = []
     questions: List[str] = []
+    messages: List[ChatMessage] = []
+
+
+class GapAskRequest(BaseModel):
+    analysis_type: str
+    messages: List[ChatMessage]
+    user_input: str
 
 
 class TeamGapRequest(BaseModel):

--- a/api/services/gap_analysis.py
+++ b/api/services/gap_analysis.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 
 from openai import OpenAI
 
-from ..schemas.gap import GapReportOut
+from ..schemas.gap import GapReportOut, ChatMessage
 from .prompts import GAP_ANALYSIS_PROMPTS
 
 
@@ -31,7 +31,7 @@ class GapAnalysisAgent:
         content = response.choices[0].message.content
         self.messages.append({"role": "assistant", "content": content})
         data = json.loads(content)
-        return GapReportOut(**data)
+        return GapReportOut(**data, messages=[ChatMessage(**m) for m in self.messages])
 
     def ask(self, user_input: str) -> GapReportOut:
         """Continue the conversation with user input."""
@@ -42,4 +42,4 @@ class GapAnalysisAgent:
         content = response.choices[0].message.content
         self.messages.append({"role": "assistant", "content": content})
         data = json.loads(content)
-        return GapReportOut(**data)
+        return GapReportOut(**data, messages=[ChatMessage(**m) for m in self.messages])

--- a/tests/test_gap_analysis_routes.py
+++ b/tests/test_gap_analysis_routes.py
@@ -94,3 +94,22 @@ def test_gap_analysis_endpoints(client, monkeypatch):
         headers=headers,
     )
     assert bad_req.status_code == 400
+
+    def dummy_ask(self, user_input):
+        return gap_schemas.GapReportOut(issues=[], questions=["F"], messages=[])
+
+    monkeypatch.setattr(
+        "api.routers.gap_analysis.GapAnalysisAgent.ask", dummy_ask
+    )
+
+    ask_resp = client.post(
+        "/gap_analysis/ask",
+        json={
+            "analysis_type": "cv_analysis",
+            "messages": [],
+            "user_input": "a",
+        },
+        headers=headers,
+    )
+    assert ask_resp.status_code == 200
+    assert ask_resp.json()["questions"] == ["F"]

--- a/web/pages/apply.tsx
+++ b/web/pages/apply.tsx
@@ -70,7 +70,13 @@ export default function ApplyPage() {
         </div>
       </form>
       <div className="mt-6 space-y-4">
-        {report && <GapAnalysisPanel report={report} personaId={selected} />}
+        {report && (
+          <GapAnalysisPanel
+            report={report}
+            personaId={selected}
+            analysisType="cv_job_match"
+          />
+        )}
         {tailored && <Textarea label="Tailored CV" value={tailored} readOnly rows={10} />}
       </div>
     </main>

--- a/web/pages/persona/[id].tsx
+++ b/web/pages/persona/[id].tsx
@@ -11,16 +11,16 @@ export default function PersonaDetail() {
   const router = useRouter();
   const { id } = router.query;
   const [persona, setPersona] = useState<Persona | null>(null);
-  const [report, setReport] = useState<GapReport>({ issues: [], questions: [] });
+  const [report, setReport] = useState<GapReport>({ issues: [], questions: [], messages: [] });
   const [template, setTemplate] = useState('');
   const [format, setFormat] = useState('md');
 
   useEffect(() => {
     if (typeof id === 'string') {
       getPersona(id).then(setPersona);
-      getGapAnalysis(id)
-        .then(setReport)
-        .catch(() => setReport({ issues: [], questions: [] }));
+        getGapAnalysis(id)
+          .then(setReport)
+          .catch(() => setReport({ issues: [], questions: [], messages: [] }));
     }
   }, [id]);
 
@@ -30,7 +30,11 @@ export default function PersonaDetail() {
     <main className="space-y-6 p-8">
       <h1 className="text-2xl font-bold">{persona.name}</h1>
       <EditorPanel persona={persona} onUpdated={setPersona} />
-      <GapAnalysisPanel report={report} personaId={persona.id} />
+      <GapAnalysisPanel
+        report={report}
+        personaId={persona.id}
+        analysisType="cv_analysis"
+      />
       <div className="flex items-end gap-4">
         <div className="w-48">
           <TemplateSelector value={template} onChange={setTemplate} />

--- a/web/pages/team.tsx
+++ b/web/pages/team.tsx
@@ -95,7 +95,9 @@ export default function TeamPage() {
             {analyzing ? 'Analyzing…' : 'Analyze Team'}
           </Button>
         </form>
-        {report && <GapAnalysisPanel report={report} />}
+        {report && (
+          <GapAnalysisPanel report={report} analysisType="team_analysis" />
+        )}
       </section>
     </div>
   );

--- a/web/utils/api.ts
+++ b/web/utils/api.ts
@@ -233,9 +233,15 @@ export interface GapIssue {
   severity: string;
 }
 
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
 export interface GapReport {
   issues: GapIssue[];
   questions: string[];
+  messages: ChatMessage[];
 }
 
 export async function getGapAnalysis(id: string): Promise<GapReport> {
@@ -278,6 +284,24 @@ export async function teamGapAnalysis(req: TeamGapRequest): Promise<GapReport> {
   });
   if (!res.ok) {
     throw new Error('Failed to analyze team');
+  }
+  return res.json();
+}
+
+export interface GapAskRequest {
+  analysis_type: string;
+  messages: ChatMessage[];
+  user_input: string;
+}
+
+export async function askGapAnalysis(req: GapAskRequest): Promise<GapReport> {
+  const res = await fetch(`${API_BASE_URL}/gap_analysis/ask`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
+    body: JSON.stringify(req),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to continue gap analysis');
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary
- extend gap analysis schemas with chat messages and a follow-up request shape
- add `/gap_analysis/ask` endpoint and OpenAI agent support for conversational responses
- build chat-style GapAnalysisPanel and wire up frontend pages to continue analysis conversations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891a2fda8a883229870b19fc637e914