### PR TITLE
feat: add postgres migration script

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -161,3 +161,8 @@ Each entry includes:
 **Context**: Gap analysis returned static questions without supporting iterative dialogue.
 **Decision**: Added `GapAskRequest` schema, `/gap_analysis/ask` endpoint, and a chat-style frontend to handle sequential questions using stored messages.
 **Reasoning**: Enables multiple follow-up questions, making the gap analysis process conversational as required.
+
+## [2025-08-05T16:35:00Z] Decision: Add manual migration script for PostgreSQL
+**Context**: The API only auto-creates tables for SQLite, leaving PostgreSQL deployments without schema bootstrap.
+**Decision**: Introduced `api/migrate.py` to run `Base.metadata.create_all` against the configured Postgres database and documented usage in the README.
+**Reasoning**: Provides a simple, explicit migration step for Postgres without adding a full migration framework, aligning with existing project practices.

--- a/README.md
+++ b/README.md
@@ -52,3 +52,13 @@ The backend Docker image installs packages from `requirements.txt`. After adding
 docker compose build backend
 ```
 
+
+## 🛠️ Database Migrations
+
+When using PostgreSQL, the application does not automatically create tables. After setting `DATABASE_URL` to a Postgres connection string, run the following command once to bootstrap the schema:
+
+```bash
+python -m api.migrate
+```
+
+This applies the SQLAlchemy models to the configured database. SQLite databases are initialized automatically on startup and do not require this step.

--- a/api/migrate.py
+++ b/api/migrate.py
@@ -1,0 +1,31 @@
+"""Utility script to bootstrap the database schema for PostgreSQL.
+
+This module can be executed directly or imported. When run, it will create
+all tables defined in the SQLAlchemy models. For safety, it skips execution if
+`DATABASE_URL` points to a SQLite database, as SQLite is handled automatically
+on application startup.
+"""
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from .database import Base, engine, SQLALCHEMY_DATABASE_URL
+
+
+def run() -> None:
+    """Create database tables using SQLAlchemy metadata."""
+    if SQLALCHEMY_DATABASE_URL.startswith("sqlite"):
+        # SQLite databases are created automatically when the app starts.
+        print("SQLite environment detected; skipping explicit migration run.")
+        return
+
+    print(f"Running migrations on {SQLALCHEMY_DATABASE_URL}...")
+    try:
+        Base.metadata.create_all(bind=engine)
+    except SQLAlchemyError as exc:  # pragma: no cover - error path
+        raise SystemExit(f"Migration failed: {exc}") from exc
+    else:
+        print("Database schema is up to date.")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add `api.migrate` to bootstrap PostgreSQL schema with SQLAlchemy
- document how to run migrations in README
- log decision about manual migration script in NOTEBOOK

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891efac0e1c8322830683060aaadf28