### PR TITLE
feat: allow runtime env file path

### DIFF
--- a/NOTEBOOK.md
+++ b/NOTEBOOK.md
@@ -176,3 +176,8 @@ Each entry includes:
 **Context**: `CVParser.parse` raised `JSONDecodeError` when the model returned content with code fences or extra prose, resulting in a 500 error.
 **Decision**: Wrapped the JSON parse in a `try/except`, stripping the content and extracting the first JSON object via regex. The CV router now returns a 502 response when parsing fails.
 **Reasoning**: Improves resilience against imperfect model responses and prevents unhandled exceptions from crashing the CV parsing endpoint.
+
+## [2025-08-06 08:59:32 UTC] Decision: Allow runtime selection of `.env` file
+**Context**: The backend loaded environment variables from the nearest `.env` file without a way to override the location for different environments.
+**Decision**: Added a `--env-file` argument in `api/main.py` that loads the specified file before app initialization and updated package initialization to respect an `ENV_FILE` override.
+**Reasoning**: Enables running the service with custom configuration files, improving flexibility for testing and deployment setups.

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,8 +1,11 @@
 """PersonaForge API package initialization."""
 
+import os
 from dotenv import load_dotenv, find_dotenv
 
-# Load environment variables from a `.env` file if present. This allows the
-# backend to pick up configuration such as database URLs and secret keys when
-# running outside of Docker.
-load_dotenv(find_dotenv())
+# Load environment variables from a `.env` file if present. By default the
+# closest `.env` discovered via ``find_dotenv`` is used, but the location can be
+# overridden by defining an ``ENV_FILE`` environment variable. This makes it
+# possible to point the backend at different configuration files without
+# modifying the code.
+load_dotenv(os.environ.get("ENV_FILE", find_dotenv()))

--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,23 @@
+"""FastAPI application entrypoint."""
+
+import argparse
+import os
+from dotenv import load_dotenv, find_dotenv
+
+# Allow a custom path to an `.env` file via ``--env-file``. When provided the
+# specified file is loaded before any other imports so configuration is in
+# place for modules like the database engine.
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("--env-file", help="Path to environment file")
+args, _ = parser.parse_known_args()
+
+if args.env_file:
+    load_dotenv(args.env_file, override=True)
+else:  # Fall back to the closest `.env` discovered automatically
+    load_dotenv(find_dotenv())
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-import os
 
 from .routers import api_router
 from .database import Base, engine, SQLALCHEMY_DATABASE_URL
@@ -28,3 +45,9 @@ app.add_middleware(
 )
 
 app.include_router(api_router)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("api.main:app", host="0.0.0.0", port=int(os.environ.get("PORT", 8000)))


### PR DESCRIPTION
## Summary
- support ENV_FILE override during package init
- allow backend to load custom env files via --env-file
- document decision in NOTEBOOK

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689318423854832283c381318e8cf0f3